### PR TITLE
roh.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -106,7 +106,6 @@ var cnames_active = {
     , "radial": "ckgrafico.github.io/radial.js"
     , "rafaelbiten": "rafaelbiten.github.io"
     , "rafaelmangolin": "rafaelMangolin.github.io"
-    , "roh": "roh7.github.io"
     , "rp": "rpocklin.github.io"
     , "rwu": "rwu823.github.io"
     , "saturation": "saturation.github.io/www"


### PR DESCRIPTION
Removing roh7.github.io for the time being, as the project has been postponed.