### PR TITLE
learngitbranching.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -105,6 +105,7 @@ var cnames_active = {
     , "labelauty": "fntneves.github.io/jquery-labelauty"
     , "laubstein": "laubstein.github.io"
     , "leandro": "leandrowd.github.io"
+    , "learnGitBranching": "pcottle.github.io/learnGitBranching"
     , "leipzig": "leipzigjs.github.io"
     , "lightyrs": "lightyrs.github.io"
     , "liguori": "liguori.github.io"


### PR DESCRIPTION
LearnGitBranching is a semi-popular tutorial and sandbox for Git that's entirely in the browser:

http://pcottle.github.io/learnGitBranching/

More info here in the README of course:
https://github.com/pcottle/learnGitBranching

I've added the CNAME file to the gh-pages of the repository:
https://github.com/pcottle/learnGitBranching/blob/gh-pages/CNAME

Hoping it's ok to request "learnGitBranching" since that's what everyone knows the page as :)