### PR TITLE
Renamed e8johan/tiny to e8johan/tiny-js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -209,7 +209,7 @@ var cnames_active = {
     , "thundercats": "r3dm.github.io/thundercats"
     , "timerizer": "callumacrae.github.io/timerizerJS"
     , "tint": "tintjs.github.io"
-    , "tinylinux": "e8johan.github.io/tiny"
+    , "tinylinux": "e8johan.github.io/tiny-js"
     , "ts2jsdoc": "spatools.github.io/ts2jsdoc"
     , "ultcombo": "ultcombo.github.io"
     , "unexpected": "unexpectedjs.github.io"


### PR DESCRIPTION
Just because we had such fun to get this to work, I decided that "tiny" was a bit too generic in my end as well. I hope that it will work out of the box this time around.