### PR TITLE
nocturnl.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -149,6 +149,7 @@ var cnames_active = {
     , "ng-wig": "stevermeister.github.io/ngWig"
     , "ngn": "nodengn.github.io/NGN"
     , "nikolay": "nikolay.github.io"
+    , "nocturnl": "nocturnl.github.io"
     , "notmeirl": "notmeirl.github.io"
     , "nsisodiya": "nsisodiya.github.io"
     , "objectmodel": "sylvainpolletvillard.github.io/ObjectModel"


### PR DESCRIPTION
Added nocturnl.github.io to the list of subdomains. Thanks, all.