### PR TITLE
riot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -176,7 +176,6 @@ var cnames_active = {
     , "react-autosuggest": "moroshko.github.io/react-autosuggest"
     , "react-shared": "rvikmanis.github.io/react-shared"
     , "relate": "jakelazaroff.github.io/relate"
-    , "riot": "riot.github.io"
     , "rp": "rpocklin.github.io"
     , "rwu": "rwu823.github.io"
     , "saturation": "saturation.github.io/www"


### PR DESCRIPTION
According to [this](https://github.com/riot/riot/issues/773#issuecomment-109979255) topic we decided democratically to use riotjs.com instead of riot.js.org, so I would like to remove riot from your dns list. I am sorry for my previous pull request and for the time you have wasted merging my stuff into the master. I am still a big fan of this project and I am sure I will use it in future maybe with one of my private stuff.
Thanks again :v: 