### PR TITLE
opentype.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -158,6 +158,7 @@ var cnames_active = {
     , "olimsaidov": "olimsaidov.github.io"
     , "omega": "jczimm.github.io/omega"
     , "on": "clayendisk.github.io/on.js"
+    , "opentype": "nodebox.github.io/opentype.js"
     , "opsigor": "opsigor.github.io"
     , "os": "andersevenrud.github.io/OS.js-v2"
     , "paraiba": "paraibajs.github.io"


### PR DESCRIPTION
Requesting to add opentype.js.

Here's the [CNAME](https://github.com/nodebox/opentype.js/blob/gh-pages/CNAME) in the opentype.js repository.

