### PR TITLE
documentation.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -71,6 +71,7 @@ var cnames_active = {
     , "dbo": "z3ta.github.io/dbo"
     , "delegacias-fortaleza": "juliosampaio.github.io/delegacias-fortaleza"
     , "dns": "js-org.github.io/dns"
+    , "documentation": "documentationjs.github.io",
     , "drag-drop": "clayendisk.github.io/drag-drop.js"
     , "dragonslayer": "kingscott.github.io/dragon-slayer"
     , "elf": "elfjs.github.io"


### PR DESCRIPTION
I haven't added a CNAME file to the [repository](https://github.com/documentationjs/documentationjs.github.io) because I'm not sure of the consequences: this site is already live at http://documentationjs.github.io/. Wouldn't adding the CNAME file before documentation.js.org is resolvable result in documentationjs.github.io effectively going offline?

Refs https://github.com/documentationjs/documentationjs.github.io/issues/2.