### PR TITLE
campinas.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -66,6 +66,7 @@ var cnames_active = {
     ,"burst": "hugeen.github.io/burst"
     ,"cable": "whatgoodisaroad.github.io/cablejs"
     ,"calcy": "odevlord.github.io/Calcy"
+    ,"campinas": "jscampinas.github.io/campinas"
     ,"cartodb-demo": "opensas.github.io/cartodb-demo"
     ,"chrislaughlin": "chrislaughlin.github.io"
     ,"chrismendis": "chrismendis.github.io"


### PR DESCRIPTION
Adding entry for `campinas.js.org` pointing to http://jscampinas.github.io/campinas.

Thanks a million @indus ! :smiley: 