### PR TITLE
Restricting node.js.org

### DIFF
--- a/cnames_restricted.js
+++ b/cnames_restricted.js
@@ -143,6 +143,7 @@ var cnames_restricted = [
     "newsgroup(s)",
     "newsletter(s)",
     "ninja(s)",
+    "node",
     "now",
     "ns1",
     "ns2",


### PR DESCRIPTION
Maybe node.js.org should be on the restricted list to avoid confusion with [nodejs.org](http://nodejs.org).