### PR TITLE
bestof.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -57,6 +57,7 @@ var cnames_active = {
     ,"badrudeen": "badrudeen.github.io"
     ,"barcelona": "barcelona-js.github.io/website"
     ,"begin": "advanced-webapps-class.github.io/begin"
+    ,"bestof": "michaelrambeau.github.io/bestofjs"
     ,"biu": "aprilorange.github.io/biu"
     ,"brandonmerritt": "brandonmerritt.github.io"
     ,"brum": "brumjs.github.io"


### PR DESCRIPTION
Hello,
First of all, thank you for this great service you provide to the open source community!
I have added the entry `bestof`, linked to the application http://michaelrambeau.github.io/bestofjs
It would be great to have this URL working: http://bestof.js.org

The purpose of the application is to have one place to check the latest tendencies about "the web platform" (JavaScript libraries, modules, frameworks...), hence the name "bestof.js.org".

Could you please merge this change ?
Thank you in advance!