### PR TITLE
redux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -224,6 +224,7 @@ var cnames_active = {
     ,"reader": "ruanyl.github.io/js-reader"
     ,"realtime": "datamcfly.github.io/realtimejs"
     ,"redis": "noderedis.github.io/node_redis"
+    ,"redux": "rackt.github.io/redux"
     ,"relate": "jakelazaroff.github.io/relate"
     ,"riotgear": "riotgear.github.io" //CF
     ,"rp": "rpocklin.github.io"


### PR DESCRIPTION
As proposed in rackt/redux#890.

Waiting on the CNAME in rackt/redux#896, but should be good to set up ahead of that.