### PR TITLE
gun.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -84,7 +84,7 @@ var cnames_active = {
     , "gridsplit": "assetinfo.github.io"
     , "gruft": "nikola.github.io/gruft"
     , "gully": "nmabhinandan.github.io/gully"
-    , "gun": "amark.github.io/gun"
+    , "gun": "gundb.github.io"
     , "happy": "e24.github.io/happy"
     , "hello": "hello-js-org.github.io"
     , "hooloo": "hooloo.github.io"


### PR DESCRIPTION
Hopefully I did this correctly.

We're wanting to change gun.js.org to point to our new dedicated website repo rather than having the website repo in the main code.

See https://github.com/js-org/dns.js.org/pull/286 for reference.

Hopefully I did this correctly. Thanks so much!