### PR TITLE
campinas.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -66,7 +66,6 @@ var cnames_active = {
     ,"burst": "hugeen.github.io/burst"
     ,"cable": "whatgoodisaroad.github.io/cablejs"
     ,"calcy": "odevlord.github.io/Calcy"
-    ,"campinas": "jscampinas.github.io/campinas"
     ,"cartodb-demo": "opensas.github.io/cartodb-demo"
     ,"chimon2000": "chimon2000.github.io"
     ,"chrislaughlin": "chrislaughlin.github.io"


### PR DESCRIPTION
Releasing `campinas.js.org` because we have opted for a top TLD for this conference.

Thanks very much for the stay. :wink: 