### PR TITLE
sass.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -260,6 +260,7 @@ var cnames_active = {
     ,"rp": "rpocklin.github.io"
     ,"ruhuman": "ruhuman.github.io"
     ,"saadmir": "saadmir.github.io"
+    ,"sass": "medialize.github.io/playground.sass.js"
     ,"saulosantiago": "saulosilva.github.io"
     ,"savingthrow": "pdistefano.github.io/SavingThrow.js"
     ,"schisma": "schisma.github.io/opensource"


### PR DESCRIPTION
Sass.js is the project that's bringing sass compiling in the browser.
We are using the sass.js repo strictly for the Sass.js library so instead the website of the project resides in playground.sass.js, hope that's not a problem.