### PR TITLE
request.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -262,6 +262,7 @@ var cnames_active = {
     ,"relate": "jakelazaroff.github.io/relate"
     ,"remark": "wooorm.github.io/remark"
     ,"rene": "revrng.github.io"
+    ,"request": "request.github.io"
     ,"riotgear": "riotgear.github.io" //CF
     ,"rishav": "xrisk.github.io/rishav"
     ,"rp": "rpocklin.github.io"


### PR DESCRIPTION
:wave: 

We're planning on pushing a new website for request here: https://request.gitbooks.io/request/content/

As you can see it's a work in progress, but we're really planning on putting some quality content there, you can check out the relevant discussion here: https://github.com/request/request/issues/1987

I think we're just going to redirect to GitBook from our index.html for now. Otherwise GitBook have similar option for custom domains:

![domain](https://cloud.githubusercontent.com/assets/1694112/12080723/c7898dde-b26c-11e5-9416-1f91980c12bf.png)

That's the repo: https://github.com/request/request.github.io