### PR TITLE
waterline.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -334,7 +334,6 @@ var cnames_active = {
     ,"vncz": "xvincentx.github.io/vncz"
     ,"voloshins": "voloshins.github.io"
     ,"vuongdothanhhuy": "vuongdothanhhuy.github.io"
-    ,"waterline": "waterlinejs.github.io"
     ,"weaver": "maxkfranz.github.io/weaver"
     ,"wwb": "eqielb.github.io/wwb"
     ,"xprmntl": "xprmntl.github.io"


### PR DESCRIPTION
waterline.js.org is pointing to a page for our project waterline (https://github.com/balderdashy/waterline) is owned by someone who is no longer associated with the project and has recently become more and more publicly hostile toward our team. We'd like to remove the link to waterline.js.org until we can figure out a way to work it out with the owner of that page. (Right now it is pretty misleading to people viewing it, because it uses our logo and looks like an official page that we are maintaining.)