### PR TITLE
pad.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -235,6 +235,7 @@ var cnames_active = {
     ,"opentype": "nodebox.github.io/opentype.js"
     ,"opsigor": "opsigor.github.io"
     ,"os": "os-js.github.io/OS.js"
+    ,"pad": "ebraminio.github.io/pad.js"
     ,"pamatcher": "pmros.github.io/pamatcher"
     ,"paperclip": "crcn.github.com/paperclip.js.org"
     ,"paraiba": "paraibajs.github.io"


### PR DESCRIPTION
I wonder if it would be possible to add this script I've just made as p.js.org so it can be used as easy as `curl p.js.org | node` :) . Even thought it is short in code but over the time it proved its usefulness for myself and that's why I made it public in hope it would be useful for others. You may wonder how the html page here could be interpreted as a nodejs script also which with having a look at its source you will see the trick I've incorporated :) Thank you