### PR TITLE
apicluster.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -382,4 +382,5 @@ var cnames_active = {
     ,"youtube-box": "lucasmonteverde.github.io/youtube-box"
     ,"zodiac": "indus.github.io/Zodiac"
     ,"zombie": "assaf.github.io/zombie"
+    , "apicluster": "ramsunvtech.github.io/apicluster"
 }


### PR DESCRIPTION
Please merge this to create domain for API Cluster Node Module for Endpoint URL Library.

Github Page: http://ramsunvtech.github.io/apicluster/
Expected URL: apicluster.js.org
Added the CNAME File to `gh-pages` branch