### PR TITLE
json-schema-faker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -208,7 +208,7 @@ var cnames_active = {
     ,"jets": "nexts.github.io/Jets.js" //CF
     ,"jjlc": "k-yak.github.io/JJLC"
     ,"josuedanielbust": "josuedanielbust.github.io"
-    ,"json-schema-faker": "pateketrueke.github.io/json-schema-faker"
+    ,"json-schema-faker": "json-schema-faker.github.io/website-jsf"
     ,"juancarlosqr": "juancarlosqr.github.io"
     ,"julien": "julien.github.io"
     ,"juno-106": "stevengoldberg.github.io/juno-106"


### PR DESCRIPTION
Our project is getting bigger and bigger and we want to move the website (gh-pages branch) to a separate repo, it would make our lifes easier :) the [new address](http://json-schema-faker.github.io/website-jsf/) is working. Hope it's fine to switch the source repo...?

