### PR TITLE
lychee.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -230,6 +230,7 @@ var cnames_active = {
     ,"liguori": "liguori.github.io"
     ,"logo": "js-org.github.io/logo"
     ,"ls": "links-js.github.io"
+    ,"lychee": "Artificial-Engineering.github.io/lycheeJS-website"
     ,"markmsmith": "markmsmith.github.io" //CF
     ,"martin": "martinbutler.github.io"
     ,"martingollogly": "martingollogly.github.io"


### PR DESCRIPTION
This will add lychee to the js.org DNS config. We try to migrate to the awesome js.org community.

The current content is hosted at [lycheejs.org](http://lycheejs.org). The domains will move to lychee.js.org once this has been merged. As we have some initial seed nodes, we currently migrate the required json config files (for the p2p websocket connections) also to the [lycheeJS-website](https://github.com/Artificial-Engineering/lycheeJS-website) repository.

Note that the build process pushes everything to the `./build` folder, which is mapped to the `gh-pages` branch.

:white_check_mark: I have read and accepted the [ToS](http://dns.js.org/terms.html).

