### PR TITLE
lychee.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -229,7 +229,7 @@ var cnames_active = {
     ,"liguori": "liguori.github.io"
     ,"logo": "js-org.github.io/logo"
     ,"ls": "links-js.github.io"
-    ,"lychee": "Artificial-Engineering.github.io/lycheeJS-website"
+    ,"lychee": "Artificial-Engineering.github.io/lycheeJS-website" //CF
     ,"markmsmith": "markmsmith.github.io" //CF
     ,"martin": "martinbutler.github.io"
     ,"martingollogly": "martingollogly.github.io"


### PR DESCRIPTION
This will add the trailing cloudflare (//CF) flag to the end of the line behind the lychee.js.org entry.

Cross-reference where I missed to add it was pull-request #664 .


Thanks in advice again!