### PR TITLE
aplayer.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -54,6 +54,7 @@ var cnames_active = {
     ,"aping": "johnnythetank.github.io/apiNG"
     ,"api-spec": "api-spec.github.io"
     ,"apicluster": "ramsunvtech.github.io/apicluster"
+    ,"aplayer": "diygod.github.io/APlayer"
     ,"apod": "marcosflorencio.github.io/angular-apod"
     ,"argo": "albertosantini.github.io/argo"
     ,"arime": "ninbryan.github.io/arime"


### PR DESCRIPTION
Subdomain for [APlayer](https://github.com/DIYgod/APlayer).

Thanks.