### PR TITLE
moose.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -291,6 +291,7 @@ var cnames_active = {
     ,"mom": "momjs.github.io/mom" // CF
     ,"momentum": "wemakeweb.github.io/momentum"
     ,"monkberry": "monkberry.github.io"
+    ,"moose": "mustpax.github.io/moose" // CF
     ,"morocco": "moroccojs.github.io" // CF
     ,"motapc": "motapc97.github.io"
     ,"mpe": "weareroli.github.io/mpejs"


### PR DESCRIPTION
I'd like to host https://mustpax.github.io/moose/ under http://moose.js.org

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

