### PR TITLE
dprof.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -172,6 +172,7 @@ var cnames_active = {
     ,"donavon": "donavon.github.io" //noCF? (don´t add this in a new PR)
     ,"dope": "fouad.github.io/dope" //noCF? (don´t add this in a new PR)
     ,"dplayer": "diygod.github.io/DPlayer" //noCF? (don´t add this in a new PR)
+    ,"dprof": "andreasmadsen.github.io/dprof"
     ,"draft": "D1SC0tech.github.io/draft.js" //noCF? (don´t add this in a new PR)
     ,"drag": "classicoldsong.github.io/Drag.js" //noCF? (don´t add this in a new PR)
     ,"dragon": "sabertazimi.github.io/dragonjs" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content)). _Because the CNAME is set, it can't be viewed right now, but check the `/docs` folder._
 - [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)

---

`dprof` is a profiling and debugging tool for getting a highly detailed overview ones application. The "gh-pages" contains an online dump viewer, for both personal and uploaded dumps.

repo: https://github.com/AndreasMadsen/dprof