### PR TITLE
liveflow.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -569,7 +569,6 @@ var cnames_active = {
     ,"sunsistemo": "sunsistemo.github.io/sunsistemo"
     ,"supernova": "janbiasi.github.io/supernova" //noCF? (don´t add this in a new PR)
     ,"swichit": "dongryphon.github.io/switchit"
-    ,"thingamajig": "hasharray.github.io/thingamajig"
     ,"tagster": "goschevski.github.io/tagster" //noCF? (don´t add this in a new PR)
     ,"talker": "secondstreet.github.io/talker.js" //noCF? (don´t add this in a new PR)
     ,"tap-flux": "technologyadvice.github.io/tap-flux" //noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -318,6 +318,7 @@ var cnames_active = {
     ,"leandro": "leandrowd.github.io" //noCF? (don´t add this in a new PR)
     ,"learnGitBranching": "pcottle.github.io/learnGitBranching" //noCF? (don´t add this in a new PR)
     ,"leipzig": "leipzigjs.github.io" //noCF? (don´t add this in a new PR)
+    ,"liveflow": "hasharray.github.io/liveflow.js",
     ,"leoj": "leoaj.github.io" //noCF? (don´t add this in a new PR)
     ,"lessmd": "linuxenko.github.io/lessmd"
     ,"leste": "atwood-cai.github.io/leste.js" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
This is a rename of thingamajig.js.org, so I'm not quite sure what the right way to go about it would be.

Keep the old entry for 301 redirects for a short time?