### PR TITLE
okan.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -405,6 +405,7 @@ var cnames_active = {
     ,"objectmodel": "sylvainpolletvillard.github.io/ObjectModel" //noCF? (don´t add this in a new PR)
     ,"oec": "crellison.github.io/oec"
     ,"oib": "andreicek.github.io/oib.js"
+    ,"okan": "okan.github.io"
     ,"omaha": "omahajs.github.io"
     ,"omega": "jczimm.github.io/omega" //noCF? (don´t add this in a new PR)
     ,"omer": "omeroot.github.io" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
added "okan.github.io" for "okan" subdomain

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
