### PR TITLE
risingstars2016.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -513,6 +513,7 @@ var cnames_active = {
     ,"reshift": "hasharray.github.io/reshift.js"
     ,"riotgear": "riotgear.github.io"
     ,"rishav": "xrisk.github.io"
+    ,"risingstars2016": "michaelrambeau.github.io/risingstars2016"		
     ,"rivki": "mikqi.github.io"
     ,"rmodal": "zewish.github.io/rmodal.js" //noCF? (don´t add this in a new PR)
     ,"router-advanced": "oldergod.github.io/router-advanced"


### PR DESCRIPTION
Hello Stefan and all project members,
I created a mini-site to explain the JavaScript landscape in 2016.
It's called "2016 JavaScript Rising Stars" because it's an analysis of the 2016 trends on Github.
You can check on Github pages: https://michaelrambeau.github.io/risingstars2016/

It would be great to have the URL http://risingstars2016.js.org

FYI I created http://bestof.js.org/ in 2015, your `.js.org` domain is really a great idea.
Thank you in advance!

## Screenshot

![image](https://cloud.githubusercontent.com/assets/5546996/21954791/4e1a8050-da9f-11e6-994c-29c93740c75e.png)

## Legal stuff

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)


