### PR TITLE
chatexchange.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -116,6 +116,7 @@ var cnames_active = {
     ,"central-node": "central-node.github.io" //noCF? (don´t add this in a new PR)
     ,"checklist": "hellogreg.github.io/checklist"
     ,"cheerio": "cheeriojs.github.io/cheerio"
+    ,"chatexchange": "jacob-gray.github.io/ChatExchangeJS"
     ,"chernivtsi": "chernivtsijs.github.io" //noCF? (don´t add this in a new PR)
     ,"chimon2000": "chimon2000.github.io" //noCF? (don´t add this in a new PR)
     ,"chrislaughlin": "chrislaughlin.github.io" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Added `chatexchange` entry. Current site can be found at https://jacob-gray.github.io/ChatExchangeJS/ (Or source at https://github.com/Jacob-Gray/ChatExchangeJS/tree/gh-pages)

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
