### PR TITLE
service-mocker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -546,6 +546,7 @@ var cnames_active = {
     ,"serender": "youssefkababe.github.io/serender" //noCF? (don´t add this in a new PR)
     ,"serginator": "serginator.github.io" //noCF? (don´t add this in a new PR)
     ,"serializer": "haircvt.github.io/serializerjs" //noCF? (don´t add this in a new PR)
+    ,"service-mocker": "service-mocker.github.io/service-mocker"
     ,"shaily": "shailysangwan.github.io"
     ,"shedali": "shedali.github.io" //noCF? (don´t add this in a new PR)
     ,"shortquery": "s--minecraft.gitbooks.io/shortquery-js" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

Add `service-mocker`. Currently the site is served at https://service-mocker.github.io/service-mocker.