### PR TITLE
uuid.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -649,6 +649,7 @@ var cnames_active = {
     ,"uni": "arcadiogarcia.github.io/UNIJS" //noCF? (don´t add this in a new PR)
     ,"upresent": "bobbybee.github.io/uPresent" //noCF? (don´t add this in a new PR)
     ,"utscrooms": "sunakujira1.github.io/UTSCRooms"
+    ,"uuid":"rumkin.github.io/uuid"
     ,"uvcharts": "imaginea.github.io/uvCharts" //noCF? (don´t add this in a new PR)
     ,"vaguilar": "vaguilar.github.io" //noCF? (don´t add this in a new PR)
     ,"valentin": "valentinvieriu.github.io" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
uuid.js.org is a minimalistic UUID generator. I'm planning to add more useful information about uuid on this page.

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
