### PR TITLE
gotanda.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -249,7 +249,7 @@ var cnames_active = {
     ,"girls": "girls-js.github.io"
     ,"gol": "goljs.github.io/GoL"
     ,"goodseller": "goodseller.github.io" //noCF? (don´t add this in a new PR)
-    ,"gotanda": "gotandajs.github.io" //noCF? (don´t add this in a new PR)
+    ,"gotanda": "gotandajs.github.io"
     ,"graphics2d": "keyten.github.io/Graphics2D" //noCF? (don´t add this in a new PR)
     ,"grapnel": "engineeringmode.github.io/Grapnel.js" //noCF? (don´t add this in a new PR)
     ,"greg": "gregorydgarcia.github.io" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I'd like to enable SSL (https://gotanda.js.org)

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)