### PR TITLE
cryptokey.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -152,6 +152,7 @@ var cnames_active = {
     ,"cracked": "billorcutt.github.io/Cracked"
     ,"crepido": "lukeramsden.github.com/crepido"
     ,"crunch": "vukicevic.github.io/crunch" //noCF? (don´t add this in a new PR)
+    ,"cryptokey": "rumkin.github.com/crypto-key"
     ,"cucumber-mink": "adezandee.github.io/cucumber-mink" //noCF? (don´t add this in a new PR)
     ,"cycle": "cyclejs.github.io"
     ,"d4": "joelburget.github.io/d4"


### PR DESCRIPTION
Add crypto key to generate eddsa crypto key online.

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
