### PR TITLE
reactql.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -562,6 +562,7 @@ var cnames_active = {
 ,"react-toulouse": "moox.github.io/react-toulouse"
 ,"reactabular": "bebraw.github.io/reactabular"
 ,"reactdesktop": "gabrielbull.github.io/react-desktop" //noCF? (don´t add this in a new PR)
+,"reactql": "leebenson.github.io/reactql-site"
 ,"reader": "ruanyl.github.io/js-reader" //noCF? (don´t add this in a new PR)
 ,"realt": "vnkitaev.github.io/realt"
 ,"realtime": "datamcfly.github.io/realtimejs" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Adds reactql.js.org -> leebenson.github.io/reactql-site

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
