### PR TITLE
faux.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -244,6 +244,7 @@ var cnames_active = {
 ,"facepalm": "santiagogil.github.io/facepalm"
 ,"farfetchd": "achannarasappa.github.io/farfetchd" //noCF? (don´t add this in a new PR)
 ,"fariz": "farizdev.github.io/fariz"
+,"faux": "fauxOS.github.io"
 ,"fcbosque": "cronopio.github.io/fcbosque" //noCF? (don´t add this in a new PR)
 ,"feeble": "feeblejs.github.io/feeble"
 ,"fela": "rofrischmann.github.io/fela" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
The fauxOS.github.io domain is not being hosted by pages at the moment. My main content directory at the moment is located right here : https://fauxOS.github.io/docs/. Thank you for this service!

- There is reasonable content on the page - I have started writing documentation and am nowhere near finished. The project being hosted has been worked on more than a month so far.

- I have read and accepted the [ToS](http://dns.js.org/terms.html) - Ja