### PR TITLE
opentype.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -505,7 +505,7 @@ var cnames_active = {
 ,"onebang": "teamtofu.github.io/onebang"
 ,"onedesert": "onedesert.github.io" //noCF? (don´t add this in a new PR)
 ,"onlineth": "onlineth.github.io"
-,"opentype": "nodebox.github.io/opentype.js" //noCF? (don´t add this in a new PR)
+,"opentype": "nodebox.github.io/opentype.js"
 ,"os": "91.247.228.125" //noCF
 ,"osom": "kikobeats.github.io/osom"
 ,"pad": "ebraminio.github.io/pad.js" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I want to upgrade the opentype.js.org domain to SSL. This domain is still using the non-SSL version.

I've searched around and couldn't find any instructions on how to the upgraded,   so I removed the (automatically added)  `//noCF? (don´t add this in a new PR)`. I hope I'm doing this correctly!