### PR TITLE
bootstrap-vue.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -111,7 +111,7 @@ var cnames_active = {
 ,"bool": "booljs.github.io"
 ,"bootstrap-confirmation": "mistic100.github.io/Bootstrap-Confirmation" //noCF? (don´t add this in a new PR)
 ,"bootstrap-validate": "pascalebeier.github.io/bootstrap-validate"
-,"bootstrap-vue": "bootstrap-vue.github.io" //noCF  
+,"bootstrap-vue": "bootstrap-vue.github.io"
 ,"bornaeon": "bornaeon.github.io" //noCF
 ,"boundless": "enigma-io.github.io/boundless"
 ,"box": "capacitorset.github.io/box-js" //noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -111,6 +111,7 @@ var cnames_active = {
 ,"bool": "booljs.github.io"
 ,"bootstrap-confirmation": "mistic100.github.io/Bootstrap-Confirmation" //noCF? (don´t add this in a new PR)
 ,"bootstrap-validate": "pascalebeier.github.io/bootstrap-validate"
+,"bootstrap-vue": "bootstrap-vue.github.io" //noCF  
 ,"bornaeon": "bornaeon.github.io" //noCF
 ,"boundless": "enigma-io.github.io/boundless"
 ,"box": "capacitorset.github.io/box-js" //noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)

Hey there :) We love to move [bootstrap-vue](https://bootstrap-vue.github.io/) to `.js.org` domain. I've temportary [disabled](https://github.com/bootstrap-vue/bootstrap-vue.github.io/commit/93a7fb385ce76da5e942e6e9910f967082700bb3) CNAME as enabling rediraction breaks our current visitors. But deployment is ready to add it back as soon as DNS was ready :)