### PR TITLE
bestofjs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -101,7 +101,7 @@ var cnames_active = {
 ,"bc": "mazko.github.io/bc.js"
 ,"be": "davidep87.github.io/bejs.github.io"
 ,"begin": "advanced-webapps-class.github.io/begin" //noCF? (don´t add this in a new PR)
-,"bestof": "michaelrambeau.github.io/bestofjs" //noCF? (don´t add this in a new PR)
+,"bestof": "michaelrambeau.github.io/bestofjs"
 ,"bildepunkt": "bildepunkt.github.io" //noCF? (don´t add this in a new PR)
 ,"bind-action-dispatchers": "cchamberlain.github.io/bind-action-dispatchers" //noCF? (don´t add this in a new PR)
 ,"biu": "aprilorange.github.io/biu" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Hello Stefan,
Would it be possible to enable https for bestof.js.org?
Note: the sub-domain initial request was made in September 2015 (#433)
Thank you in advance!

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content)): **YES**
- I have read and accepted the [ToS](http://dns.js.org/terms.html): **YES**
