### PR TITLE
picodom.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -603,6 +603,7 @@ var cnames_active = {
 ,"pharaoh": "pharaoh-js.github.io" //noCF? (don´t add this in a new PR)
 ,"phobos": "phobosjs.github.io/phobos.js"
 ,"photo-sphere-viewer": "mistic100.github.io/Photo-Sphere-Viewer" //noCF? (don´t add this in a new PR)
+,"picodom": "picodom.github.io"
 ,"picsim": "mazko.github.io/picsim.js"
 ,"piii": "theuves.github.io/piii.js" //noCF? (don´t add this in a new PR)
 ,"pinf": "pinf.github.io" //noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Hi @indus! 👋 
 
Can we add [picodom](https://github.com/picodom/picodom)? 

Picodom is a 1 KB Virtual DOM builder and patch function.

![screen shot 2017-07-22 at 2 21 50](https://user-images.githubusercontent.com/56996/28474729-a6e71918-6e84-11e7-82dc-14b36c9da676.png)


This is essentially a knock-off of [HyperApp](https://hyperapp.js.org)'s VDOM's engine published as a separate module.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)
