### PR TITLE
vuelog.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -907,6 +907,7 @@ var cnames_active = {
   "vscode-apielements": "xvincentx.github.io/vscode-apielements",
   "vue-land": "egoist.github.io/vue-land",
   "vue-mdc": "na-west1.surge.sh",
+  "vuelog": "myst729.github.io/Vuelog",
   "vuikit": "vuikit.github.io",
   "vuongdothanhhuy": "vuongdothanhhuy.github.io", // noCF? (don´t add this in a new PR)
   "wanna": "mkermani144.github.io/wanna",


### PR DESCRIPTION
Hi this is Leo. I crafted a blog system called [**vuelog**](https://github.com/myst729/Vuelog). I'd like to use **vuelog.js.org** to serve the docs of the project.

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
