### PR TITLE
Add konstructor to cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -439,6 +439,7 @@ var cnames_active = {
   "klasa": "dirigeants.github.io/klasa",
   "knowyourbundle": "enapupe.github.io/know-your-bundle",
   "komada": "dirigeants.gitbooks.io/komada-docs",
+  "konstructor": "server.ludicrous.xyz",
   "konsumer": "konsumer.github.io", // noCF? (don´t add this in a new PR)
   "kyoto": "kyotojs.github.io",
   "labelauty": "fntneves.github.io/jquery-labelauty", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

Hello,

I would like to request `konstructor.js.org` to point to my own custom CNAME, because konstructor is a framework I am working on and it would be cool if the main page could be powered by the framework itself. You can see an existing, working version [here](https://konstructor.ludicrous.xyz/). The page is a bit empty right now, but I plan on adding docs really soon. Just wanted to set up the server and domain first to make sure it all works.

Thanks!