### PR TITLE
komada.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -439,7 +439,7 @@ var cnames_active = {
   "kite": "kite-js.github.io/kite",
   "klasa": "dirigeants.github.io/klasa",
   "knowyourbundle": "enapupe.github.io/know-your-bundle",
-  "komada": "dirigeants.gitbooks.io/komada-docs",
+  "komada": "dirigeants.github.io/komada",
   "konstructor": "server.ludicrous.xyz",
   "konsumer": "konsumer.github.io", // noCF? (don´t add this in a new PR)
   "kyoto": "kyotojs.github.io",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

This is updating Komada's documentation site from it's old gitbooks site to our new custom site on GH Pages.