### PR TITLE
jdceeb2.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -425,6 +425,7 @@ var cnames_active = {
   "jargon": "hugogiraudel.github.io/SJSJ", // noCF? (don´t add this in a new PR)
   "javascript-kitchen": "jskitchen.github.io",
   "jbone": "kupriyanenko.github.io/jbone", // noCF? (don´t add this in a new PR)
+  "jdceeb2": "kdiacodes.github.io/jdc",
   "jets": "nexts.github.io/Jets.js",
   "jet": "alexanderbartels.github.io/jet-website",
   "jinya": "chenjinya.github.io",


### PR DESCRIPTION
There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))

I have read and accepted the [ToS](http://dns.js.org/terms.html)

on line 428 "jdceeb2": "kdiacodes.github.io/jdc"
however you might have to use kdiacodes.js.org/jdc instead (?).
