### PR TITLE
jdc.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -427,7 +427,7 @@ var cnames_active = {
   "jargon": "hugogiraudel.github.io/SJSJ", // noCF? (don´t add this in a new PR)
   "javascript-kitchen": "jskitchen.github.io",
   "jbone": "kupriyanenko.github.io/jbone", // noCF? (don´t add this in a new PR)
-  "jdc": "kdiacodes.github.io/jdc",
+  "jdc": "jdceeb.github.io",
   "jets": "nexts.github.io/Jets.js",
   "jet": "alexanderbartels.github.io/jet-website",
   "jinya": "chenjinya.github.io",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

I've moved my repository from https://github.com/KDiaCodes/jdc (which doesn't exist any more) to https://github.com/jdceeb/jdceeb.github.io and i'd like my domain to follow.

In the README file it says if it's a project repo then i should use a gh-pages branch but since it's a main .github.io page it wont let me. Is that ok even though it's a project page?