### PR TITLE
frint.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -335,7 +335,7 @@ var cnames_active = {
   "foxman": "kaola-fed.github.io/foxman",
   "freemarker": "ijse.github.io/freemarker.js", // noCF? (don´t add this in a new PR)
   "freezer": "pakastin.github.io/freezer",
-  "frint": "travix-international.github.io/frint",
+  "frint": "frintjs.github.io/frint.js.org",
   "fritzbox": "lesander.github.io/fritzbox.js",
   "front-end": "whoisjorge.github.io/front-end",
   "frzr": "pakastin.github.io/frzr",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

---

## As of now

Previously, I submitted #987 for frint.js.org, and was accepted. Many thanks for that!

We extracted our website to a separate repository here: https://github.com/frintjs/frint.js.org

The project's monorepo is still here currently: https://github.com/Travix-International/frint

## Merge strategy

Unfortunately, GitHub won't allow two repos to share the same `CNAME` at the same time, so we need a bit of help from you here :)

If you could kindly tell us the date/time when you intend to merge this PR, I can drop the CNAME from old repo, and push it to the new repo a few minutes before then. 

This will help us minimize the downtime for the domain.

Thanks!