### PR TITLE
risingstars.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -832,7 +832,7 @@ var cnames_active = {
   "riotgear": "riotgear.github.io",
   "rishav": "xrisk.github.io",
   "risingstars2016": "michaelrambeau.github.io/risingstars2016",
-  "risingstars": "bestofjs.github.io/javascript-risingstars",
+  "risingstars": "risingstars.netlify.com",
   "rivki": "mikqi.github.io",
   "rmodal": "zewish.github.io/rmodal.js",
   "rock": "w3core.github.io/RockJS",


### PR DESCRIPTION
Sorry for this second request in 2 days (see #1663), but I didn't know we could also use Netlify.

It would be better for our application because we need the "redirect" feature of Netlify, to be able to redirect smoothly users from the root level `/` to `/2017/en` for example.

FYI we have already a `CNAME` file on Netlify, filled with: `risingstars.js.org`

Thank you again!

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)

  
  