### PR TITLE
trinity.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1004,6 +1004,7 @@ var cnames_active = {
   "trevorgk": "trevorgk.github.io", // noCF? (don´t add this in a new PR)
   "trier": "creimers.github.io/trier",
   "trilogy": "citycide.github.io/trilogy",
+  "trinity": "marcus-sa.github.io/trinity-js",
   "troxel": "troxeljs.github.io",
   "true-myth": "chriskrycho.github.io/true-myth",
   "try-catch-finally": "c24w.github.io/try-catch-finally.js",


### PR DESCRIPTION
I'd like https://trinity.js.org for https://marcus-sa.github.io/trinity-js

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
  