### PR TITLE
amaple.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1111,7 +1111,8 @@ var cnames_active = {
   "zeit": "vinhpz.github.io",
   "zodiac": "indus.github.io/Zodiac", // noCF? (don´t add this in a new PR)
   "zombie": "assaf.github.io/zombie", // noCF? (don´t add this in a new PR)
-  "zp": "tilda.ws"
+  "zp": "tilda.ws",
+  "amaple": "amjs-team.github.io"
   /*
   * please don"t add your subdomain records down here!
   * insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
I want to get the "amaple.js.org" for our org javascript project which named "amaplejs", thank you.
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
