### PR TITLE
filehub.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -342,6 +342,7 @@ var cnames_active = {
   "feeble": "feeblejs.github.io/feeble",
   "fela": "rofrischmann.github.io/fela", // noCF? (don´t add this in a new PR)
   "festercluck": "festercluck.github.io", // noCF? (don´t add this in a new PR)
+  "filehub": "minegamer5570.github.io/Filehub",
   "filer": "filerjs.github.io/filer",
   "filter": "filterjs.github.io/docs",
   "finder": "applait.github.io/finderjs", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
minegamer5570.github.io/Filehub to filehub.js.org

The site doesn't have much right now, but it will have more in the future. Storing files and stuff... I can hold off the js.org domain for now until it is ready for use. You choose and let me know.

Thanks!

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
