### PR TITLE
djvu.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -266,6 +266,7 @@ var cnames_active = {
   "distillery": "achannarasappa.github.io/distillery", // noCF? (don´t add this in a new PR)
   "distri": "flarp.github.io/Distri.js",
   "distribution": "distributionjs.github.io/website",
+  "djvu": "russcoder.github.io/djvujs",
   "djzhao": "djzhao627.github.io",
   "dmitry": "dmitry-zaets.github.io",
   "dns": "js-org.github.io/dns.js.org",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content)), however since I created CNAME in the gh-pages branch, now GitHub redirects me to the djvu.js.org and the website doesn't work at all. 
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
