### PR TITLE
Remove basebot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -118,7 +118,6 @@ var cnames_active = {
   "bandung": "zufrizalyordan.github.io/bandungjs",
   "barbagrigia": "barbagrigia.github.io",
   "barcelona": "barcelona-js.github.io/website", // noCF? (don´t add this in a new PR)
-  "basebot": "iagrib.github.io/Basebot",
   "bash": "bashjs.github.io", // noCF? (don´t add this in a new PR)
   "basicgame": "basicgame.github.io/basicGame.js", // noCF? (don´t add this in a new PR)
   "bastion": "snkrsnkampa.github.io/Bastion-Site",


### PR DESCRIPTION
Hello,

I'd like to free up `basebot.js.org` (added with #1483) because that project was discontinued and removed from github for several reasons, thus the domain is no longer used.

Thanks!