### PR TITLE
backstage.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -115,6 +115,7 @@ var cnames_active = {
   "awoo": "awoojs.github.io/website",
   "azdanov": "azdanov.github.io",
   "backlog": "backlog-js.github.io/backlog.js.org", // noCF? (don´t add this in a new PR)
+  "backstage": "jessepinho.github.io/backstage",
   "badger": "just-glue-it.github.io/badger", // noCF? (don´t add this in a new PR)
   "badrudeen": "badrudeen.github.io", // noCF? (don´t add this in a new PR)
   "bali": "balijs.github.io",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
  - **Note:** I removed the `CNAME` file from the [repo](https://github.com/jessepinho/backstage), so now you should be able to actually see the content at http://jessepinho.github.io/backstage/. If it still redirects to `.js.org`, try opening it in an Incognito window.
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
