### PR TITLE
dusansimic.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -305,7 +305,6 @@ var cnames_active = {
   "dualcyclone": "dualcyclone.github.io/postit-todo-react-redux",
   "duffn": "duffn.github.io", // noCF? (don´t add this in a new PR)
   "dunedin": "dunedinjs.github.io",
-  "dusansimic": "dusansimic.github.io", // noCF
   "dutchakdev": "dutchakdev.github.io", // noCF? (don´t add this in a new PR)
   "dynaflo": "trevorhanus.github.io/dynaflo",
   "dynamicsnode": "crisfervil.github.io/DynamicsNode",


### PR DESCRIPTION
I would like to remove dusansimic.js.org from the list (added: https://github.com/js-org/dns.js.org/pull/1605) since the page is using another domain from now on.

Thanks.
