### PR TITLE
octo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -733,6 +733,7 @@ var cnames_active = {
   "nyc": "nycjsorg.github.io/nyc",
   "nyr": "suriyaakudoisc.github.io/NYR",
   "objectmodel": "sylvainpolletvillard.github.io/ObjectModel", // noCF? (don´t add this in a new PR)
+  "octo": "baileyjm02.github.io/OctoJS",
   "oec": "crellison.github.io/oec",
   "ohmy": "mountainwang.github.io/ohmy",
   "oib": "andreicek.github.io/oib.js",


### PR DESCRIPTION
I've added octo (octo.js.org) that points too https://baileyjm02.github.io/OctoJS

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
