### PR TITLE
hubble.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -469,6 +469,7 @@ var cnames_active = {
   "hoa": "thehoa.github.io",
   "hooloo": "hooloo.github.io", // noCF? (don´t add this in a new PR)
   "hub": "yyued.github.io/hub.js",
+  "hubble": "sevenoutman.github.io/Hubble",
   "huck": "huckjs.github.io/huck",
   "human": "human-js.gitbooks.io", // noCF? (don´t add this in a new PR)
   "humanreadable": "matt-sanders.github.io/humanreadable", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Add hubble.js.org at [sevenoutman.github.io/Hubble](https://sevenoutman.github.io/Hubble).

Btw should I add CNAME before this PR or afterwards? I tried adding it but that way I can't access the Pages via the original address.