### PR TITLE
set chat.js.org to JavaScriptRoom.github.io

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -201,6 +201,7 @@ var cnames_active = {
   "cats": "whoisjorge.github.io/not-cat-gifs",
   "central-node": "central-node.github.io", // noCF? (don´t add this in a new PR)
   "chain-able": "fluents.github.io/chain-able-site",
+  "chat":"JavaScriptRoom.github.io",
   "chatexchange": "jacob-gray.github.io/ChatExchangeJS",
   "checklist": "hellogreg.github.io/checklist",
   "cheerio": "cheeriojs.github.io/cheerio",


### PR DESCRIPTION
The chat.js.org domain is on the `cnames_restricted.js` list.  So this may or not be approved depending on the discussion [here](https://github.com/js-org/dns.js.org/issues/1898).

Right now the page http://javascriptroom.github.io/rules is up and activately used.

Index.html will hopefully eventually link to the actually site through a redirect.  I have requested a pull request for [that](https://github.com/JavaScriptRoom/JavaScriptRoom.github.io/pull/4/commits/d73c7edcf20dfefa624b62797e00b8a41e84b0b6).  I believe this is a valid and useful use of the http://chat.js.org link.  

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
