### PR TITLE
funfuncs.js.org / hosting.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -412,7 +412,6 @@ var cnames_active = {
   "frzr": "pakastin.github.io/frzr",
   "fs-nextra": "bdistin.github.io/fs-nextra",
   "funbook": "egoist.github.io/funbook",
-  "funfuncs": "floffah.github.io/funfuncs",
   "fyi": "tobihrbr.github.io/fyi",
   "g": "nodebox.github.io/g.js",
   "gal": "galmail.github.io", // noCF? (don´t add this in a new PR)
@@ -469,6 +468,7 @@ var cnames_active = {
   "hk": "akura-co.github.io/hk", // noCF? (don´t add this in a new PR)
   "hoa": "thehoa.github.io",
   "hooloo": "hooloo.github.io", // noCF? (don´t add this in a new PR)
+  "hosting": "hosting.floffah.co.uk", // or floffah.github.io/hosting (the dns zones have not fully updated yet) if you are wondering this is a website where you can host npm packages/projects and will be tested every so often buy website admins.
   "hub": "yyued.github.io/hub.js",
   "hubble": "sevenoutman.github.io/Hubble",
   "huck": "huckjs.github.io/huck",


### PR DESCRIPTION
Funfuncs is going to be deprecated.
(the dns zones have not fully updated yet but when they do use hosting.floffah.co.uk or floffah.github.io/hosting) if you are wondering this is a website where you can host npm packages/projects and will be tested every so often by website admins.

When this project is finished, you may start getting people requesting subdomains but instead of using github pages it would be using http://hosting.floffah.co.uk/exampleuser/examplenodeproject/jekyll-pages/

Join my discord? https://discord.gg/Pn5eYnk . My website was recently deleted since i am redesigning it. For now use http://social.floffah.co.uk (a facebook like social thing that doesn't breach the end user license agreements) and http://media.floffah.co.uk (upload images and share them with friends)

There is reasonable content on the page (see: No Content)
I have read and accepted the ToS

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
