### PR TITLE
hubble.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -474,7 +474,7 @@ var cnames_active = {
   "hoa": "thehoa.github.io",
   "hooloo": "hooloo.github.io", // noCF? (don´t add this in a new PR)
   "hub": "yyued.github.io/hub.js",
-  "hubble": "sevenoutman.github.io/Hubble",
+  "hubble": "hubble.netlify.com",
   "huck": "huckjs.github.io/huck",
   "human": "human-js.gitbooks.io", // noCF? (don´t add this in a new PR)
   "humanreadable": "matt-sanders.github.io/humanreadable", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I'm the owner of Hubble. Recently Hubble has been moved from GitHub Pages to Netlify (at https://hubble.netlify.com) to take advantage of its OAuth service, and I would like to point `hubble.js.org` to the new host, following [their docs](https://www.netlify.com/docs/custom-domains/).