### PR TITLE
styled-icons.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1083,6 +1083,7 @@ var cnames_active = {
   "stuck": "linuxenko.github.io/unstuck-webpack",
   "style": "dhilipsiva.github.io/style.js", // noCF? (don´t add this in a new PR)
   "styled-css-grid": "styled-css-grid.netlify.com",
+  "styled-icons": "styled-icons.netlify.com",
   "styletron": "rtsao.github.io/styletron", // noCF? (don´t add this in a new PR)
   "stylis": "thysultan.github.io/stylis.js",
   "sub": "subjs.github.io",


### PR DESCRIPTION
This adds `styled-icons.js.org` => `styled-icons.netlify.com`.  Netlify should already be configured to accept the CNAME.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)
