### PR TITLE
moeditor.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -701,6 +701,7 @@ var cnames_active = {
   "modbot": "modbotjs.github.io",
   "modofun": "modofunjs.github.io/modofun",
   "modv": "2xaa.github.io/modV",
+  "moeditor": "moeditor.github.io",
   "mog-script": "mog-script.github.io",
   "mohit": "mohitgarg.github.io",
   "mol": "eigenmethod.github.io/mol", // noCF


### PR DESCRIPTION
Add moeditor.js.org at [`moeditor.github.io`](https://moeditor.github.io). A `CNAME` has been added into [the repo](https://github.com/Moeditor/moeditor.github.io).