### PR TITLE
redux-actions.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -934,7 +934,7 @@ var cnames_active = {
   "redis": "noderedis.github.io/node_redis", // noCF? (don´t add this in a new PR)
   "redom": "redom.github.io/redom",
   "reduce": "reducejs.github.io", // noCF? (don´t add this in a new PR)
-  "redux-actions": "vinnymac.gitbooks.io/redux-actions",
+  "redux-actions": "hosting.gitbook.com", // noCF
   "redux-data-structures": "adrienjt.github.io/redux-data-structures",
   "redux-loop": "redux-loop.github.io/redux-loop",
   "redux-minimal": "catalin-luntraru.github.io/redux-minimal",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

The official documentation of [`redux-actions`](https://github.com/redux-utilities/redux-actions) is now accessible on https://redux-utilities.gitbook.io/redux-actions/ and we don't need the [fork](https://github.com/vinnymac/redux-actions) anymore.