### PR TITLE
warrior.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1232,7 +1232,7 @@ var cnames_active = {
   "wanna": "mkermani144.github.io/wanna",
   "wargamer": "hkwu.github.io/wargamer",
   "warnbot": "darkcoding-js.github.io/WarnBot",
-  "warrior": "warriorjs.github.io",
+  "warrior": "olistic.github.io/warriorjs",
   "watch": "ducin.github.io/watchjs.org", // noCF? (don´t add this in a new PR)
   "wayou": "wayou.github.io", // noCF? (don´t add this in a new PR)
   "wdd": "wangduanduan.github.io",


### PR DESCRIPTION
Hi, I'd like to point https://warrior.js.org to the [project's page](https://olistic.github.io/warriorjs) instead of the organization page, where it's currently pointing. Thanks 😄 

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

This is the PR where the domain was originally added: #1240 
