### PR TITLE
conductor.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -245,6 +245,7 @@ var cnames_active = {
   "community.luxaura": "trikel.paradox.cloud", //noCF
   "community.os": "js.bydiscourse.com", // noCF? (don´t add this in a new PR)
   "concursos": "mteyss.github.io/concursos", // noCF? (don´t add this in a new PR)
+  "conductor": "waldojeffers.gitbook.io/conductor",
   "construyendotrabajo": "mteyss.github.io/construyendotrabajo", // noCF? (don´t add this in a new PR)
   "consultant": "jense5.github.io/consultant",
   "contextify": "abemedia.github.io/jquery-contextify", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Hello, I'd like to add [Conductor](https://waldojeffers.gitbook.io/conductor) to this list :)

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- [x] I have read and accepted the [ToS](http://dns.js.org/terms.html)

btw, the [first example](http://autocrat.js.org/) on the No-Content page does not work 😢 
