### PR TITLE
neutrino.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -741,7 +741,7 @@ var cnames_active = {
   "nemaniarjun": "nemaniarjun.github.io",
   "nemo": "paypal.github.io/nemo", // noCF? (don´t add this in a new PR)
   "neo4": "janpeter.github.io/neo4js",
-  "neutrino": "hosting.gitbook.com", // noCF
+  "neutrino": "mozilla-neutrino.github.io/neutrino-dev",
   "nflow": "nflow-js.github.io", // noCF? (don´t add this in a new PR)
   "ng-dux": "mister-what.github.io/ngDux",
   "ng-wig": "stevermeister.github.io/ngWig", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Reverts js-org/dns.js.org#1938

Need to revert this until Gitbook can fix some of their bugs.