### PR TITLE
async-af.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -107,6 +107,7 @@ var cnames_active = {
   "astral": "espinielli.github.io/astraljs", // noCF? (don´t add this in a new PR)
   "astrobench": "kupriyanenko.github.io/astrobench", // noCF? (don´t add this in a new PR)
   "astx-redux-util": "kevinast.github.io/astx-redux-util",
+  "async-af": "asyncaf.github.io/AsyncAF",
   "atavic": "atavic.github.io",
   "atombundles": "lirantal.github.io/atombundles",
   "audio-cat": "tporl.github.io/audio-cat",


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

Note: while the github project page is [AsyncAF/AsyncAF](https://github.com/AsyncAF/AsyncAF/tree/master), the library on NPM is known as [async-af](https://www.npmjs.com/package/async-af) so I'm going with that as the subdomain.

Thanks!!!
