### PR TITLE
verse.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1209,7 +1209,7 @@ var cnames_active = {
   "vayne": "vaynejs.github.io",
   "vbuild": "egoist.github.io/vbuild",
   "verifyr": "arze1.github.io/verifyr-site",
-  "verse": "druidic.github.io/verse", // noCF
+  "verse": "druidic.github.io/verse",
   "vico": "bohdantkachenko.github.io/vico", // noCF? (don´t add this in a new PR)
   "video-react": "video-react.github.io",
   "vinimdocarmo": "vinimdocarmo.github.com", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I'd like to add CloudFlare to my (existing) domain, [verse.js.org](verse.js.org). Is that possible? I realized I need HTTPS for my site's service worker to function.

Thanks so much for maintaining dns.js.org!

- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)
