### PR TITLE
minecraft-data.prismarine.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -706,6 +706,7 @@ var cnames_active = {
   "milesgitgud": "milesgitgud.github.io/homepage",
   "mimic": "500tech.github.io/mimic",
   "mina": "CenturyUna.github.io/mina",
+  "minecraft-data.prismarine": "prismarinejs.github.io/minecraft-data",
   "minesweeper": "derflatulator.github.io/minesweeper",
   "mingjie": "mj66.github.io/mingjie.info",
   "mingyi": "liangmingyi.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- There is reasonable content on the page (see: [No Content](https://github.com/js-org/dns.js.org/wiki/No-Content))
- I have read and accepted the [ToS](http://dns.js.org/terms.html)

Previously, we had documentation available at `prismarinejs.github.io/minecraft-data`, now it appears that we cannot access that path. According to https://help.github.com/articles/custom-domain-redirects-for-github-pages-sites/, it appears that you are supposed to add a `CNAME` to your sub-project, then GitHub will have it redirect to a subdomain rather than a path on the original CNAME. This is why a request for [minecraft-data.prismarine.js.org](minecraft-data.prismarine.js.org) has been created.