### PR TITLE
groupme.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1092,6 +1092,7 @@ var cnames_active = {
   "greylock": "datamart.github.io/Greylock",
   "gridiron": "noderaider.github.io/gridiron",
   "gridsplit": "assetinfo.github.io", // noCF? (don´t add this in a new PR)
+  "groupme": "not-so-smart.github.io/node-groupme",
   "grub": "grubburg.github.io/blog",
   "gruft": "nikola.github.io/gruft", // noCF? (don´t add this in a new PR)
   "grumpy": "aidenybai.github.io/grumpy",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

This is for a library called `node-groupme` that I'm writing for interacting with the GroupMe API. It's still in development so there isn't a lot of content for the website yet. I'm hoping that the current state of the page counts as "not-very-shiny but valid" as opposed to "no content".

I checked out the "no content" wiki page and can't tell whether this violates the rules. If it helps, the package has a couple hundred downloads so far on npm (https://www.npmjs.com/package/node-groupme) and a relatively active repository (https://github.com/not-so-smart/node-groupme) with a couple contributors and many active issues.

I plan to use this site to host documentation for the library (https://github.com/not-so-smart/node-groupme/blob/main/docs/index.html) but I haven't figured out how to do that yet.

Hopefully this is evidence enough that my request is in good faith and not simply an excuse to "park" domains. 