### PR TITLE
Fix cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -733,7 +733,7 @@ var cnames_active = {
   "div": "div-js.github.io/div.js.org",
   "diysay": "diysay.github.io/diysay-js-org",
   "djs-tools": "fhgdev.github.io/djs-tools",
-  "djs-addon": "hosting.gitbook.io" // noC"
+  "djs-addon": "hosting.gitbook.io", // noC"
   "djsframe": "vypal.github.io/djsframe",
   "djsguide": "hosting.gitbook.com",
   "djvu": "russcoder.github.io/djvujs", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

I am the maintainer of [js.org.json](https://github.com/raikasdev/js.org.json) and I noticed that the .js file is invalid, as my CI was failing.
So I fixed, and added the `,`