### PR TITLE
bundle.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -380,7 +380,7 @@ var cnames_active = {
   "bui": "kjantzer.github.io/bui",
   "bullwinkle": "bullwinkle.github.io",
   "bun": "the94air.github.io/bun",
-  "bundle": "bundlejs.netlify.app",
+  "bundle": "bundlejs.vercel.app",
   "bunjil": "bunjil.netlify.com",
   "bunyan-fork": "cchamberlain.github.io/bunyan-fork", // noCF? (don´t add this in a new PR)
   "bunyan-pmx": "cchamberlain.github.io/bunyan-pmx", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Move bundle.js.org from bundlejs.netlify.app to bundlejs.vercel.app

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
