### PR TITLE
eslint-plugin-wxml.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -883,6 +883,7 @@ var cnames_active = {
   "escape": "licshee.github.io/Escape.js", // noCF? (don´t add this in a new PR)
   "esfx": "esfx.github.io",
   "esg": "cname.vercel-dns.com", // noCF
+  "eslint-plugin-wxml": "eslint-plugin-wxml.vercel.app",
   "esper": "codecombat.github.io/esper.js",
   "estudiantil": "milersant.github.io/estudiantil",
   "eta": "alias.zeit.co", // noCF


### PR DESCRIPTION
Hi, `js-org` maintainers. I am npm package [eslint-plugin-wxml](https://www.npmjs.com/package/eslint-plugin-wxml)'s owner. I want to register `eslint-plugin-wxml.js.org` as home page domain. Thanks

> https://github.com/wxmlfile/eslint-plugin-wxml

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
