### PR TITLE
guildedts.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1153,6 +1153,7 @@ var cnames_active = {
   "guildcord": "guildcord.github.io/docs",
   "guilded": "guildedjs.github.io/guilded.js",
   "guildedapi": "rellylegend.github.io/guilded-api.js",
+  "guildedts": "guildedts.github.io/guilded.ts",
   "guilherme": "guilhermedelemos.github.io/guilherme",
   "guillotine": "matiasgagliano.github.io/guillotine", // noCF? (don´t add this in a new PR)
   "gully": "nmabhinandan.github.io/gully", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Added the `guildedts` subdomain.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
