### PR TITLE
fancy-pants.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -994,7 +994,7 @@ var cnames_active = {
   "fakeyou": "leunamcrack.github.io/fakeyou.js",
   "fallr": "faisalman.github.io/fallr-js",
   "fan": "garychamberlain.github.io/fan",
-  "fancy-pants": "sukima.github.io/fancy-pants",
+  "fancy-pants": "fancy-pants.tritarget.org",
   "fantas": "fantastiser.github.io",
   "farfetch": "websitebeaver.github.io/far-fetch",
   "farfetchd": "achannarasappa.github.io/farfetchd", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I've moved the hosting of the FancyPants JS library from github to another hosting service.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
