### PR TITLE
inboxigniter.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1419,7 +1419,6 @@ var cnames_active = {
   "iffe": "iffe-team.github.io",
   "iflow": "unadlib.github.io/iflow",
   "igecorp": "igecorp.github.io/ige-djs-website",
-  "inboxigniter": "ghosthosted.github.io",
   "ignite": "ignitejscl.github.io",
   "iiimix": "iiimix.github.io/iiimixjsorg",
   "iio": "iioinc.github.io/iio.js", // noCF? (don´t add this in a new PR)
@@ -1439,6 +1438,7 @@ var cnames_active = {
   "impress": "impress.github.io/impress.js",
   "imrc-datetime-picker": "smrsan76.github.io/imrc-datetime-picker",
   "imvu": "imvujs.pages.dev", // noCF
+  "inboxigniter": "ghosthosted.github.io/inboxigniter",
   "indie": "indie-org.github.io/indie",
   "infinite-tree": "cheton.github.io/infinite-tree",
   "infoooze": "devxprite.github.io/infoooze",


### PR DESCRIPTION
Hello,
I’d like to request the subdomain inboxigniter.js.org for my project after I fixed the naming, content and alphabetical order.

Requesting inboxigniter.js.org

- GitHub username: ghosthosted
- Custom domain: inboxigniter.js.org
- Project folder: /inboxigniter
- Repo: https://github.com/ghosthosted/ghosthosted.github.io
- CNAME file included at /inboxigniter
- Site is live and clean with relevant content about email copywriting and marketing
- GitHub username inboxigniter was unavailable, so I used ghosthosted instead
- Entry has been placed alphabetically under "imvu" in cname_active.js

Thanks for your time and consideration!