### PR TITLE
doll.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -866,6 +866,7 @@ var cnames_active = {
   "dogstack": "dogstack.gitbooks.io", // noCF
   "dokdo": "wonderlandpark.github.io/dokdo",
   "dolan": "cname.vercel-dns.com", // noCF
+  "doll": "01033139027.github.io/Doll",
   "dollar": "defims.github.io/dollar",
   "dolphin": "uyouthe.github.io/dolphin",
   "domainr": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION

Requesting the subdomain doll.js.org for my JavaScript tools website.

Live site: https://01033139027.github.io/Doll  
This project includes practical tools like:
- Random number generator
- Square calculator
- URL encoder / decoder

Thanks for providing free subdomains to the JS community!

