### PR TITLE
sri-marker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2966,7 +2966,7 @@ var cnames_active = {
   "squirrelly": "squirrellyjs.netlify.app", // noCF
   "sr": "samrobbins85.github.io",
   "sri": "jackub.github.io/subresource-integrity-fallback",
-  "sri-maker": "rohit-chouhan.github.io/sri-maker", 
+  "sri-maker": "rohit-chouhan.github.io/sri-maker",
   "sri-shasum": "imcotton.github.io/sri", // noCF
   "ss": "cname-china.vercel-dns.com", // noCF
   "sse": "dt-is-not-available.github.io/sse",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://rohit-chouhan.github.io/sri-maker/

> The site content is a modern Subresource Integrity (SRI) hash generator called **sri-marker**.  
> It provides a browser-based tool to generate SRI hashes (sha256/384/512) for JavaScript and CSS files,  
> supporting URL fetch, source code input, and file uploads. The tool also generates ready-to-use  
> integrity attributes and embed code, with a responsive UI built using Bulma and hosted via GitHub Pages.
