### PR TITLE
bluematter.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -372,6 +372,7 @@ var cnames_active = {
   "bloxy": "visualizememe.github.io/bloxy",
   "blu": "maxherrmann.github.io/blu",
   "blueconfig": "a-312.github.io/node-blueconfig",
+  "bluematter": "bluematterin.github.io/pubdev-verification",
   "blurple": "blurplejs.github.io/docs",
   "bo": "lfb.github.io/bojs",
   "boats": "discordboats.github.io",


### PR DESCRIPTION
Add BlueMatter github page

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
- Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
- Add a link (GitHub repository, Vercel deployment, etc.) and explanation below for your content so we can validate your request

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://bluematterin.github.io/pubdev-verification/

> The site content is the official GitHub Pages site for **BlueMatter**, a developer brand publishing apps and open-source packages.  
It currently contains the verification files and a minimal landing page, and will be expanded to include documentation, links to packages on pub.dev, and project information.  

