### PR TITLE
dailypixels.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -936,6 +936,7 @@ var cnames_active = {
   "dynamotion": "cname.vercel-dns.com", // noCF`
   "dyo": "dyo.github.io/dyo",
   "dyte": "dytejs.github.io",
+  "dailypixels": "dailypixels.github.io",
   "e-query": "mjkhonline.github.io/e-query",
   "eagleeye": "webkrafters.github.io/eagleeye",
   "eahmed234": "eahmed234.github.io",


### PR DESCRIPTION
Adding dailypixels.js.org → dailypixels.github.io

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://dailypixels.github.io

> The site content is a collection of creative stories, articles, and projects built with HTML, CSS, and JavaScript. It showcases modern web design and frontend interactivity — relevant to the JavaScript and open web community.
