### PR TITLE
westharborbooks.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3525,6 +3525,7 @@ var cnames_active = {
   "welcome": "edapm.github.io/welcomejs",
   "welson": "gnh1201.github.io/welsonjs",
   "wepl": "obnoxiousnerd.github.io/wepl-website",
+  "westharborbooks": "westharborbooks.github.io/westharborbooks",
   "wfplayer": "zhw2590582.github.io/WFPlayer",
   "wglt": "codyebberson.github.io/wglt",
   "whadido": "jokester.github.io/whadido",


### PR DESCRIPTION
I'd like to request the subdomain westharborbooks.js.org for my Github Pages site at https://westharborbooks.github.io/westharborbooks.  I've added the entry to the cnames_active.js as instructed.  Thank you!

