### PR TITLE
dailypixels.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -931,6 +931,7 @@ var cnames_active = {
   "dvan": "dvan.netlify.app",
   "dvd": "cdaringe.github.io/dvd-corner-bounce",
   "dynaflo": "trevorhanus.github.io/dynaflo",
+  "dailypixels": "dailypixels.github.io",
   "dynamic-record": "na-west1.surge.sh",
   "dynamicsnode": "crisfervil.github.io/DynamicsNode",
   "dynamotion": "cname.vercel-dns.com", // noCF`


### PR DESCRIPTION
Adding dailypixels.js.org → dailypixels.github.io

- [x] There is reasonable content on the page (see: https://github.com/js-org/js.org/wiki/No-Content)
- [x] I have read and accepted the Terms and Conditions (http://js.org/terms.html)

> The site content is a JavaScript-focused web project showcasing creative web designs, interactive UI features, and front-end development examples using HTML, CSS, and JS.

Repository link: https://github.com/dailypixels/dailypixels.github.io
Live preview: https://dailypixels.github.io
