### PR TITLE
discord.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -798,7 +798,7 @@ var cnames_active = {
   "dipole": "zheksoon.github.io/dipole",
   "discm": "cname.vercel-dns.com", // noCF
   "discmds": "whitecluegaming.github.io/discmds",
-  "discord": "cname.vercel-dns.com", // noCF
+  "discord": "discordjs-website.crawlgg.workers.dev",
   "discord-achievements": "shadowplay1.github.io/da-docs",
   "discord-addons": "freiikdev.github.io/discord-addons",
   "discord-anti-spam": "michael-j-scofield.github.io/discord-anti-spam",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://discord.js.org/ or https://discordjs.dev/

> The site content is a reference documentation for https://github.com/discordjs/discord.js

I have not seen a single workers.dev domain in that list so far. Unsure if this is the correct approach to add this, or if it is even possible to have a CNAME from a Zone that is not owned by the account the worker runs on pointing to it(?)
