### PR TITLE
compactr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -599,6 +599,7 @@ var cnames_active = {
   "commitlint": "conventional-changelog.github.io/commitlint",
   "common-utils": "common-utils.netlify.app",
   "common-utils-pkg": "iamdevlinph.github.io/common-utils-pkg",
+  "compactr": "compactr.github.io",
   "composedb": "ceramicstudio.github.io/js-composedb",
   "composify": "composify-js.github.io/composify",
   "composite": "compositejs.github.io",


### PR DESCRIPTION
Added compactr.js.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [compactr.github.io](https://compactr.github.io)

> The site content is a landing page for the javascript library compactr (available on npm). Compactr is a schema-based serialization library that has been out since 2016... and now, with the eve of v3.0, it finally has a website. Thanks Claude!
