### PR TITLE
fat-chudik.js.orgs_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1092,6 +1092,7 @@ var cnames_active = {
   "farzad": "wikiweb.github.io/farzad",
   "fast-ease": "caracal7.github.io/fast-ease",
   "fasteer": "fasteerjs.github.io",
+  "fat-chudik": "DimonMasta.github.io/fat-chudik-coin",
   "faux": "fauxos.github.io",
   "fcanvas": "fcanvas.github.io/docs",
   "fcbosque": "cronopio.github.io/fcbosque", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Adding fat-chudik.js.org for Fat Chudik Coin project hosted on GitHub Pages
