### PR TITLE
Add atagulgames.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -115,6 +115,7 @@ var cnames_active = {
   "agentify": "agentify-js-org.github.io/pages",
   "agentnpm": "meetping.github.io/agentnpm",
   "agilecards": "otaklapka.github.io/agilecards",
+  "atagulgames": "ama07a.github.io/atagulshop",
   "agma": "uwynell.github.io/agma.js",
   "agrawalnaman": "agrawalnaman.github.io",
   "agrawalrohit": "rohit0803.github.io/agrawal.github.io",


### PR DESCRIPTION
This pull request adds the subdomain "atagulgames.js.org" pointing to "ama07a.github.io/atagulshop" as requested.

- Subdomain: atagulgames.js.org
- GitHub Pages repo: ama07a/atagulshop

All steps have been followed according to JS.ORG subdomain contribution guidelines.
