### PR TITLE
atagulgames.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -179,6 +179,7 @@ var cnames_active = {
   "angular-cn": "ng-docs.github.io/angular-cn.js.org",
   "angular-jsf": "json-schema-faker.github.io/angular-jsf", // noCF? (don´t add this in a new PR)
   "angular-mfe": "rx-ts.github.io/angular-mfe",
+  "atagulgames": "ama07a.github.io/atagulshop",
   "angular-redux": "angular-redux-docs.netlify.app", // noCF
   "angular-uikit": "whoisjorge.github.io/angular-uikit",
   "angular2in1": "angular2in1.github.io/angular2in1js", // noCF


### PR DESCRIPTION
This pull request adds the subdomain "atagulgames.js.org" pointing to "ama07a.github.io/atagulshop" as requested.

- Subdomain: atagulgames.js.org
- GitHub Pages repo: ama07a/atagulshop

All steps have been followed according to JS.ORG subdomain contribution guidelines.