### PR TITLE
wechaty.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3531,7 +3531,7 @@ var cnames_active = {
   "webpeer": "nuzulul.github.io/webpeerjs",
   "websheet": "pierreavn.github.io/websheetjs",
   "wechatpay": "thenorthmemory.github.io/wechatpay.js.org",
-  "wechaty": "cdn.chatie.io", // noCF
+  "wechaty": "wechaty-js-org.pages.dev",
   "wedgetail": "wedgetail.netlify.app",
   "weekly": "xdimh.github.io/weekly",
   "welcome": "edapm.github.io/welcomejs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://wechaty-js-org.pages.dev>

> The site content is Wechaty Project Website

This PR requests a JS.org subdomain for the Wechaty community website.

Domain: wechaty.js.org
Target: wechaty-js-org.pages.dev

Cloudflare Pages deployment is live and HTTPS-enabled.
The website is a reverse-proxy that merges two GitHub Pages repos:
- Docusaurus docs
- Jekyll blog

Thank you!


