### PR TITLE
webpdfs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3532,6 +3532,7 @@ var cnames_active = {
   "webpack-inspect": "alexmost.github.io/webpack-inspect",
   "webpack-stats": "v-webpack.netlify.app",
   "webpeer": "nuzulul.github.io/webpeerjs",
+  "webpdfs": "jaya-prakash1123.github.io/web",
   "websheet": "pierreavn.github.io/websheetjs",
   "wechatpay": "thenorthmemory.github.io/wechatpay.js.org",
   "wechaty": "wechaty-js-org.pages.dev",


### PR DESCRIPTION
Added a new entry for 'webpdfs' in the cnames list.

<!--
My website usually lives at https://jaya-prakash1123.github.io/web/
I want to share PDFs to a 100+ students in my class so I tried GitHub. As it can give access to any one who opens my website. It's a free pdf library that allows users to download Indian 11th, 12th textbooks without searching online
--> 
- [x ] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [ x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is ...
