### PR TITLE
comptime.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -606,7 +606,7 @@ var cnames_active = {
   "composify": "composify-js.github.io/composify",
   "composite": "compositejs.github.io",
   "compoundinterest": "nategiraudeau.github.io/compound-interest-calculator",
-  "comptime": "feathers-studio.github.io/comptime.ts",
+  "comptime": "feathers-studio.github.io/comptime.ts", // noCF
   "computed": "krmax44.github.io/rollup-plugin-computed",
   "concursos": "mteyss.github.io/concursos", // noCF? (don´t add this in a new PR)
   "conductor": "hosting.gitbook.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://comptime.js.org, if CF is not still down

> The site content is preexisting, also found at https://github.com/feathers-studio/comptime.ts/blob/master/docs/index.html. It was originally added in #9769. This isn't a knee-jerk reaction to recent CloudFlare downtimes; I don't use CF on any of my domains, and I wish not to use it for this one either. Really appreciate the js.org service though! :)