### PR TITLE
banmu.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -166,6 +166,7 @@ var cnames_active = {
   "alt": "goatslacker.github.io/alt", // noCF? (don´t add this in a new PR)
   "alveron": "cname.vercel-dns.com", // noCF
   "alyreza": "alyreza.github.io",
+  "banmu": "xingbingxin.top",
   "alys": "rmjordas.github.io/alys",
   "aman": "plug-n-play.github.io/aman",
   "amaple": "amjs-team.github.io/amaple",


### PR DESCRIPTION
This subdomain is used for personal self-hosted services and a homepage.

Repository:
https://github.com/banmuxing/banmu-home

