### PR TITLE
loadericon.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1849,6 +1849,7 @@ var cnames_active = {
   "lyra": "amansahil.github.io/lyra.js.org",
   "lyz": "lihawhaw.github.io/lyzjs",
   "lzbible": "edwinyosorahardjo.github.io/lzbible",
+  "loadericon": "loadericon.pages.dev",
   "m01i0ng": "m01i0ng.github.io",
   "m3ripple": "yuyake-litrain.github.io/m3ripple-web",
   "m8bot": "mapreiff.github.io/m8-bot-site",


### PR DESCRIPTION
A lightweight CSS-only animated loader.
URL of the site: loadericon.pages.dev 
And yes, it is called Loader Icon.
I also have accepted and readed the Terms and Conditions of js.org
The Loader Icon GitHub Repo is: https://github.com/izhank216/loadericon