### PR TITLE
resafe.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2705,7 +2705,7 @@ var cnames_active = {
   "reqoal": "aldhosutra.github.io/reqoal",
   "reqsrv": "axtk.github.io/reqsrv",
   "request": "request.gitbooks.io", // noCF? (don´t add this in a new PR)
-  "resafe": "https://ofabiodev.github.io/resafe",
+  "resafe": "ofabiodev.github.io/resafe",
   "reselect": "reselect-docs.netlify.app",
   "reshape": "reshape.netlify.app",
   "reshift": "hasharray.github.io/reshift.js",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [X] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [X] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://ofabiodev.github.io/resafe/

> The site content is The documentation for my upcoming npm package called Resafe. Resafe is a JavaScript/TypeScript library focused on analyzing and validating regular expressions to detect potential ReDoS (catastrophic backtracking) and other unsafe patterns. The documentation explains the problem domain, how the library works, its API, and provides examples relevant to the JavaScript ecosystem.

The package is not published on npm yet because I am waiting for the .js.org subdomain to be approved first, so the documentation URL can be used as the canonical reference before the initial release.

**Repository:** https://github.com/ofabiodev/resafe