### PR TITLE
opencc.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2298,6 +2298,7 @@ var cnames_active = {
   "open-api": "harys722.github.io/open-api",
   "open-next": "serverless-stack.github.io/open-next",
   "openauth": "openauthjs.github.io/openauth",
+  "opencc": "opencc-wasm.pages.dev",
   "openkey": "microlinkhq.github.io/openkey",
   "opennext": "opennextjs.github.io/docs",
   "openrecord": "philwaldmann.github.io/openrecord",


### PR DESCRIPTION
This website is a landing page for NPM package [opencc-wasm](https://npmjs.com/package/opencc-wasm), a WASM library based on [OpenCC](https://github.com/ByVoid/OpenCC), an open-sourced Chinese conversion tool.

Website code is available from https://github.com/frankslin/opencc-wasm-demo-site/ and deployed to a CloudFlare Page.

The WASM library code is available from https://github.com/frankslin/OpenCC/tree/master/wasm-lib.

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/frankslin/opencc-wasm-demo-site/ (hosted on https://opencc-wasm.pages.dev/ )

> The site content is a landing page showcasing how to use the `opencc-wasm` library available at https://www.npmjs.com/package/opencc-wasm. It doubles as a web-based Chinese (Simplified/Traditional) converter using OpenCC WASM library inside user's browser.