### PR TITLE
mdld.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1940,6 +1940,7 @@ var cnames_active = {
   "mdbf-css": "more-beautiful-div-framework.github.io",
   "mdcdev": "galleniz.github.io/mdcdev.js",
   "mdjs": "xtnmoe.github.io/MdJs",
+  "mdld": "davay42.github.io/mdld-parse",
   "mdxe": "cname.vercel-dns.com", // noCF
   "mechan": "dusterthefirst.github.io/mechan.js",
   "medan": "medan-js.github.io", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/davay42/mdld-parse/blob/main/index.html - it's a single file HTML site served from the main branch - straightforward and robust.

> The site content is the documentation for my MDLD JS parser, but also I would put my Specification draft there as it's my own development for new Semantic Markdown syntax. I would like to use mdld.js.org as a namespace there - thus I want to get the domain before publishing the spec on the site. The parser is made in JS and MDLD will be build around web ecosystem.
