### PR TITLE
commandkit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -603,7 +603,7 @@ var cnames_active = {
   "comixngn": "seun40.github.io/comix-ngn", // noCF? (don´t add this in a new PR)
   "commandcord": "commandcord.github.io",
   "commandfox": "commandfox.github.io/mc-tools", // noCF? (don´t add this in a new PR)
-  "commandkit": "216.198.79.1", // noCF
+  "commandkit": "cname.vercel-dns.com", // noCF
   "commitlint": "conventional-changelog.github.io/commitlint",
   "common-utils": "common-utils.netlify.app",
   "common-utils-pkg": "iamdevlinph.github.io/common-utils-pkg",


### PR DESCRIPTION
Updated the URL for 'commandkit' to point to vercel.

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://commandkit.vercel.app>

> The site content is the documentation for [commandkit](https://github.com/neplextech/commandkit). Vercel now suggests using ip address instead of `cname.vercel-dns.com`, therefore this PR uses the ip address instead

<img width="852" height="297" alt="image" src="https://github.com/user-attachments/assets/157d6187-17ca-4d63-afb3-4caa73a5cd62" />
