### PR TITLE
turali.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3318,7 +3318,6 @@ var cnames_active = {
   "ttgprotect": "ttgprotect.github.io",
   "tui-nuxt": "hosting.gitbook.com", // noCF
   "tulsa": "thatguysam.github.io/tulsa.js",
-  "turali": "caglarturali.github.io",
   "turbine": "tschoffelen.github.io/turbine",
   "turbo": "turbo.github.io",
   "turboprisma": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com

> The site content is [not-relevant]

I'm no longer using this domain. Thank you for your services. 🫡 
Here's the original PR that added it: #3790 
