### PR TITLE
tajudin.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1,3 +1,4 @@
+"tajudin": "tajudin143.github.io",
 {
   "cnames": {
     "taz": "taz.github.io",


### PR DESCRIPTION

Hi — thanks for reviewing and the guidance. I’ve updated the PR description and ensured the demo site contains a small open-source JavaScript demo/library for verification. The site is now published at: https://tajudin143.github.io/ and a docs/CNAME with tajudin.js.org is included. Please let me know if anything else is needed — I appreciate your time.


- [x]  There is reasonable content on the page (see: No Content)

- [x] I have read and accepted the Terms and  Conditions

The site content can be seen at: (https://tajudin143.github.io/)
The site content is a minimal open-source JavaScript demo/library intended as an educational and reference resource for the JavaScript community. It is not a personal blog or portfolio. Repository Tajudin143/Tajudin143.github.io contains:

A tiny library (Greet.js) with both distributables (UMD + ESM) committed in dist/ so it can be consumed directly in the browser.
A static demo page at docs/index.html that demonstrates both UMD (global) and ES module usage, with example code snippets and buttons to run the demo.
A README describing usage and how the demo is published on GitHub Pages.
A docs/CNAME file containing the requested subdomain: tajudin.js.org.
Purpose / relevance: the repository demonstrates module formats (UMD/ESM), packaging and GitHub Pages usage — content that helps developers learn about JavaScript module distribution and browser usage and therefore is relevant to the JavaScript community.

Single line to add to cnames_active.js (place in alphabetical order in the js.org repo):

"tajudin": "tajudin143.github.io",