### PR TITLE
tajudin.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3185,7 +3185,7 @@ var cnames_active = {
   "taha": "orcxzjeeeee.github.io/taha",
   "tailwind-baseline": "apkoponen.github.io/tailwind-baseline-site",
   "tailwindtocss": "tailwindtocss.netlify.app",
-  "tajudin": "mansuura60-arch.github.io",
+  "tajudin": "mansuura60-arch.github.io/tajudin",
   "takeout": "takeout-bysourfruit.github.io",
   "talk": "zonayedpca.github.io/talk.js",
   "talker": "secondstreet.github.io/talker.js", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: https://github.com/js-org/js.org/wiki/No-Content)
- [x] I have read and accepted the Terms and Conditions (http://js.org/terms.html)

- The site content can be seen at: https://mansuura60-arch.github.io/tajudin/

> The site content is documentation and example usage for **Tajudin Utils**, a lightweight JavaScript utility toolkit.
>The project provides reusable helper functions and patterns intended for use in modern JavaScript and frontend development. The site serves as the official documentation and demo page for the toolkit, including descriptions of its purpose and JavaScript code examples.
>This project is clearly related to the JavaScript ecosystem, is designed as a reusable library (with planned NPM distribution), and is not a personal site, blog, portfolio, or Discord bot page.
