### PR TITLE
markmapu.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1920,6 +1920,7 @@ var cnames_active = {
   "marked": "cname.vercel-dns.com", // noCF
   "markliu": "markliuyuxiang.github.io",
   "markmap": "gera2ld.github.io/markmap-lib",
+  "markmapu": "markmap-universe.github.io",
   "markmsmith": "markmsmith.github.io",
   "markvis": "geekplux.github.io/markvis",
   "markvis-editor": "geekplux.github.io/markvis-editor",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://markmap.org/, https://github.com/markmap-universe/markmap-universe.github.io

> The site content is the official website of [Markmap Universe](https://github.com/markmap-universe), an organization dedicated to building advanced tools, integrations, and infrastructure around the Markmap ecosystem.
> The current domain `markmap.org` is frequently confused with `markmap.js.org`. Migrating to `markmapu`(Markmap Universe) clarifies the distinction between the core engine and our community. Moreover, continuing to renew the current domain—or acquiring a new one—has become financially unsustainable for us.