### PR TITLE
saytoit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2845,6 +2845,7 @@ var cnames_active = {
   "saturon": "cname.vercel-dns.com", // noCF
   "saulosantiago": "saulosilva.github.io", // noCF? (don´t add this in a new PR)
   "sawyer": "sqwwy.github.io/sawyer.js.org",
+  "saytoit": "rameshreddy-adutla.github.io/saytoit",
   "sazerac": "sazeracjs.github.io/sazerac-site",
   "sb": "santiaguf.github.io",
   "sc136": "sc136.github.io/sc-136",


### PR DESCRIPTION
**Subdomain requested:** saytoit.js.org
**GitHub Pages URL:** https://rameshreddy-adutla.github.io/saytoit
**Repository:** https://github.com/rameshreddy-adutla/saytoit
**CNAME file:** Added to the repository (landing-page/CNAME contains `saytoit.js.org`)

SayToIt is an open-source macOS voice transcription app. The subdomain will point to the project's landing page hosted on GitHub Pages.