### PR TITLE
yaka.js.org Add 'yaka' CNAME entry for vercel-dns

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3682,6 +3682,7 @@ var cnames_active = {
   "yadl": "yadljs.github.io",
   "yagolopez": "yagolopez.github.io",
   "yak": "cname.vercel-dns.com", // noCF
+  "yaka": "cname.vercel-dns.com",
   "yake": "yakeing.github.io/HexoBlog",
   "yamdbf": "zajrik.github.io/yamdbf",
   "yan": "yvesyc.github.io/yan-js-org",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)

- The site content can be seen at  https://yaka-js-documentation.vercel.app/

> The site content is the official documentation and benchmark report for YakaJS. YakaJS is a high-performance, modern JavaScript utility library designed to be a faster, lightweight alternative to jQuery. It provides developers with essential DOM manipulation, event handling, and AJAX utilities using modern ES6+ standards. This site serves the JavaScript community by providing API references and performance comparison data (showing 11/12 benchmark wins over jQuery) to help developers build faster web applications.