### PR TITLE
Remove concurrency from validate workflow

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,10 +16,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   validate-cnames:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Reverts #10660 as unfortunately it seems GitHub has a bit of a race condition with workflow approvals + concurrency, whereby if there are multiple runs queued to be approved, sometimes an older run will be the one that goes through, with newer runs being cancelled. This results in the CI checks being left stuck as pending/cancelled in the PR. I have reported this to them, and they've acknowledged the issue, but I figure for now the best thing to do is remove this from our workflow so as not to continue being an annoyance.

<!--

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://js.org

> The site content is a placeholder value to keep CI happy

-->