### PR TITLE
faah.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1096,8 +1096,8 @@ var cnames_active = {
   "eye": "arguiot.github.io/EyeJS",
   "ezoradom": "4614s.github.io/ezoradom-the-functions",
   "f1": "marinofranz.github.io/f1.ts",
-  "facepalm": "santiagogil.github.io/facepalm",
   "faah": "cname.vercel-dns.com", // noCF
+  "facepalm": "santiagogil.github.io/facepalm",
   "facreative": "facreative.github.io",
   "fairy": "fairymeee.github.io",
   "fakeyou": "leunamcrack.github.io/fakeyou.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://faah-thk.vercel.app/

> The site content is documentation for **Faah**, an open-source JavaScript ecosystem tool (VS Code extension) that helps developers detect terminal/build/runtime errors with configurable alerting. The page includes product overview, setup, usage examples, and configuration references intended for JavaScript developers using modern JS/TS workflows.
