### PR TITLE
focustimerdyn.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1173,6 +1173,7 @@ var cnames_active = {
   "fnbr": "fnbrjs.github.io/docs",
   "foca": "foca-js.github.io/foca",
   "focusoverlay": "mmahandev.github.io/FocusOverlay",
+  "focustimerdyn": "focus-timer-dinamic.vercel.app",
   "fontdragr": "ryanseddon.github.io/font-dragr",
   "food": "russellsteadman.github.io/foodweb",
   "foolhtml": "itsayush1704.github.io/foolhtml",


### PR DESCRIPTION
## Summary
- Add focustimerdyn.js.org subdomain for FocusTimerDinamic project
- Project: FocusTimerDinamic - A dynamic Pomodoro timer
- Hosting: Vercel (focus-timer-dinamic.vercel.app)