### PR TITLE
Add lop9a7-k57.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3749,6 +3749,7 @@ var cnames_active = {
   "zykj": "cname.vercel-dns.com", // noCF
   "zyx": "zyx.alwaysdata.net",
   "zyy": "zyyou.github.io/notes"
+  "lop9a7-k57": "nguyenHai3122011-collab.github.io/9A7-K57",
   /*
    * please don't add your subdomain records down here!
    * insert them in alphabetical order to help reduce merge conflicts.


### PR DESCRIPTION
Adding free subdomain for my class 9A7 K57 school webpage on GitHub Pages.
- GitHub Pages URL: https://nguyenHai3122011-collab.github.io/9A7-K57/
- Contains HTML structure, CSS styling, images display, and basic JavaScript (e.g., onload alert and click event on title).
- Thank you for reviewing!