### PR TITLE
docs.webpack.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -890,6 +890,7 @@ var cnames_active = {
   "docs.light": "hosting.gitbook.com", // noCF
   "docs.modmail": "botstudios.github.io/modmail.js-docs", // noCF
   "docs.mosaic": "hosting.gitbook.io", // noCF
+  "docs.webpack": "cname.mintlify-dns.com", // noCF
   "docsify": "docsifyjs.github.io/docsify",
   "docsify-es": "sidval.github.io/docsify-es",
   "docsify-ru": "truepatch.github.io/docsify-ru",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://openjsfoundation.mintlify.app/>

> The site content is a Mintlify application at the [`docs.webpack.js.org`](https://github.com/webpack/docs.webpack.js.org) repository. This additional CNAME would redirect that subdomain to the Mintlify hosted documentation (currently under development!)