### PR TITLE
codalabs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -585,6 +585,7 @@ var cnames_active = {
   "cnc": "cncjs.github.io/cncjs.org",
   "cndrew": "codemaster233.github.io",
   "cobalt-kit": "bernzrdo.github.io/cobalt-kit",
+  "codalabs": "thecodalabs.github.io",
   "cocy": "krmax44.github.io/cocy",
   "code-tour": "code-tour.netlify.app",
   "codeberry": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Add codalabs.js.org

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

Before creating your pull request, please read and complete the following steps:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements
  - Notably, make sure that your site is not a personal site, and that it is clearly content that is relevant to the JavaScript community/ecosystem

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is ...
### Domain Request: codalabs.js.org

- **Domain:** `codalabs.js.org`
- **Target:** `thecodalabs.github.io`
- **Reason:** Professional portfolio and home for "Purposeful Software" projects (EdTech & NGO solutions) based in Tanzania.
- **Verification:** - [x] I have created the `CNAME` file in my repository.
  - [x] The site is live and accessible at the target URL.
  - [x] This is a non-commercial, developer-focused project.

Built with a minimalist "Flavio Copes" inspired design to ensure accessibility in low-bandwidth regions.