### PR TITLE
Seek further content clarity in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,8 +3,8 @@
 Thanks for creating a pull request to request a new subdomain from JS.ORG
 
 ⚠️ Before continuing, your site content MUST be DIRECTLY related to the JavaScript ecosystem/community
-Having a site that is built with JavaScript is not a justification by itself for requesting a JS.ORG subdomain
-If you cannot explain why your site is relevant to JavaScript developers specifically, JS.ORG isn't for you
+Building a website with JavaScript doesn't automatically entitle a project to a JS.ORG subdomain
+You must be able to explain why your website is specifically relevant to other JavaScript developers
 
 📝 Please read and complete the following steps to correctly submit your request:
 


### PR DESCRIPTION
We continue to see what feels like an increasing number of pull requests, likely due to the increasing prevalence of AI tooling and AI slop, with content that does not meet the criteria for JS.org as the content simply uses JavaScript but is not directly relevant to the JavaScript ecosystem/community.

As such, updating the PR template with the hope that this will guide humans, and AI agents, to think a bit more about whether they meet the requirements or not before submitting.

<!--

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://js.org

> The site content is a placeholder to keep the CI happy.

-->