### PR TITLE
scafix.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2885,6 +2885,7 @@ var cnames_active = {
   "sb": "santiaguf.github.io",
   "sc136": "sc136.github.io/sc-136",
   "scadies": "kysolva.github.io/scadies", // noCF
+  "scafix": "cname.vercel-dns.com", // noCF
   "scancell": "russellsteadman.github.io/scancell",
   "scene": "daybrush.github.io/scenejs-page",
   "schema": "hosting.gitbook.com",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://scafix.vercel.app/

> The site content is Scafix, a universal scaffolding CLI for initializing modern JavaScript application stacks, and is relevant to JavaScript developers specifically because it helps them bootstrap JS projects (Vite/Next/Express/etc.) via a consistent CLI and provides documentation and usage examples.