### PR TITLE
Add qrlab to cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2600,6 +2600,7 @@ var cnames_active = {
   "pwa-workshop": "sylvainpolletvillard.github.io/pwa-workshop",
   "py-like": "ruben-arushanyan.github.io/py-like",
   "qbit": "fudan-mse.github.io/qbit",
+  "qrlab": "syedfarhandanish.github.io",
   "qs": "kirjs.github.io/qs.js", // noCF? (don´t add this in a new PR)
   "quacky": "quacky-bot.github.io",
   "quanta": "solarbrowser.github.io/w4q",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/syedfarhandanish/qr-lab

> The site content is an open-source QR Code generation and laboratory tool built with JavaScript. It is relevant to JavaScript developers specifically because it demonstrates the implementation of QR generation libraries, provides a clean UI for testing payload data, and serves as an educational resource for frontend developers working with client-side utility tools.