### PR TITLE
Add craftix-clan.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -470,7 +470,7 @@ var cnames_active = {
   "cacophony": "ctoth.github.io/cacophony",
   "caffeine": "ccrraaiigg.github.io/caffeine",
   "caicai": "qianxunclub.github.io/CaiCai",
-  "craftix-clan": "yugsh4as-alt.github.io/craftix-website/"
+  "craftix-clan": "yugsh4as-alt.github.io/craftix-website"
   "caissa": "agentx-cgn.github.io/caissa",
   "caizhiyuannn": "caizhiyuannn.github.io",
   "calcium": "courageous-bublanina-6857c1.netlify.app",


### PR DESCRIPTION
Hello,

I would like to register the subdomain craftix-clan.js.org for my Minecraft community website.

- Project URL: https://yugsh4as-alt.github.io/craftix-website/
- The website is a single-page application built with JavaScript to showcase clan members and information.
- I have ensured that the entry in cnames_active.json is alphabetically sorted.

Thank you for providing this service!
