### PR TITLE
Add craftix-clan to cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -461,6 +461,7 @@ var cnames_active = {
   "byteforge": "piscilus.github.io/byteforge",
   "byteform": "byteform.netlify.app",
   "bytemd": "bytemd.netlify.app",
+  "craftix-clan": "yugsh4as-alt.github.io/craftix-website",
   "c": "cocobear.github.io",
   "c-3po": "ttag-org.github.io/c-3po",
   "c-installer": "llenax.github.io/c-installer",


### PR DESCRIPTION
### Subdomain Request

- [x] There is reasonable content on the page
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms.html)

**Subdomain:** craftix-clan
**URL:** https://yugsh4as-alt.github.io/craftix-website/

> The site content is a professional Minecraft clan portal for the Craftix community.
> and is relevant to JavaScript developers specifically because the entire site is built using pure JavaScript to dynamically render clan members and data.