### PR TITLE
craftix-clan.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -682,8 +682,7 @@ var cnames_active = {
   "crackabottle": "crack-a-bottle.github.io",
   "cracked": "billorcutt.github.io/Cracked",
   "craco": "dilanx.github.io/craco",
-  "craft": "cname.vercel-dns.com", // noCF
-  "crank": "bikeshaving.github.io/crank",
+  "craftix-clan": "yugsh4as-alt.github.io/craftix-website",
   "crapto1": "li0ard.github.io/crapto1_ts",
   "crawlx": "wind2sing.github.io/crawlx",
   "crawlyx": "theritikchoure.github.io/crawlyx",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://yugsh4as-alt.github.io/craftix-website/

> The site content is a JavaScript-driven portal for the Craftix Minecraft clan. 
> and is relevant to JavaScript developers specifically because it uses asynchronous JS and Fetch API to display real-time gaming server statistics.