### PR TITLE
jsedit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -116,7 +116,6 @@ var cnames_active = {
   "agahi": "teneplaysofficial.github.io/agahi",
   "agenda-tech-brasil-site": "abacatinhos.github.io/agenda-tech-brasil-site",
   "agentify": "agentify-js-org.github.io/pages",
-  "jsedit": "cname.vercel-dns.com", // noCF
   "agentnpm": "meetping.github.io/agentnpm",
   "agilecards": "otaklapka.github.io/agilecards",
   "agma": "uwynell.github.io/agma.js",
@@ -1638,6 +1637,7 @@ var cnames_active = {
   "joycon": "cname.vercel-dns.com", // noCF
   "jparticles": "jparticles.github.io/Documentation",
   "js-fixerr": "anujsinghwd.github.io/js-fixerr",
+  "jsedit": "cname.vercel-dns.com", // noCF
   "js-labs": "cname.vercel-dns.com", // noCF
   "js-utils": "teneplaysofficial.github.io/js-utils-kit",
   "js2lua": "xiangnanscu.github.io/js2lua", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://jsedit-indol.vercel.app

> The site content is a browser-based multi-language code editor powered by Monaco (the engine behind VS Code). It supports HTML, CSS, JavaScript, TypeScript, CoffeeScript, LiveScript, SCSS, and LESS with syntax highlighting, multi-file tabs, live preview, and the ability to publish projects to public /p/:slug URLs with raw file access at /r/:slug. This is relevant to JavaScript developers specifically because it provides a lightweight, zero-setup environment for prototyping, testing, and sharing JavaScript (and related web language) code directly in the browser — useful for quick experiments, debugging, or teaching without leaving the browser or installing local tooling.