### PR TITLE
ktechai.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1749,6 +1749,7 @@ var cnames_active = {
   "kremling": "canopytax.github.io/kremling.js.org",
   "kshitij": "kshitij98.github.io",
   "kst": "lucaelin.github.io/KST", // noCF
+  "ktechai": "kkai90.github.io/ktechai",
   "ktm": "developers-nepal.github.io/ktmjs",
   "kucos": "kucosjs.github.io",
   "kumeru": "ultirequiem.github.io/kumeru",


### PR DESCRIPTION
## Description

Adding subdomain `ktechai.js.org` pointing to `kkai90.github.io/ktechai`.

## Checklist
- [x] The GitHub Page is live and accessible
- [x] The content has a clear connection to JavaScript
- [x] Entry is in alphabetical order