### PR TITLE
mock-to-openapi.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2102,6 +2102,7 @@ var cnames_active = {
   "mock-cmdr": "ncjones.github.io/mock-cmdr",
   "mock-extended": "tobysmith568.github.io/mock-extended",
   "mock-middleware": "luobotang.github.io/mock-middleware",
+  "mock-to-openapi": "OzzyCzech.github.io/mock-to-openapi",
   "mockjs-lite": "52cik.github.io/mockjs-lite", // noCF
   "mockyeah": "mockyeah.netlify.app",
   "modbot": "modbotjs.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2102,7 +2102,7 @@ var cnames_active = {
   "mock-cmdr": "ncjones.github.io/mock-cmdr",
   "mock-extended": "tobysmith568.github.io/mock-extended",
   "mock-middleware": "luobotang.github.io/mock-middleware",
-  "mock-to-openapi": "OzzyCzech.github.io/mock-to-openapi",
+  "mock-to-openapi": "ozzyczech.github.io/mock-to-openapi",
   "mockjs-lite": "52cik.github.io/mockjs-lite", // noCF
   "mockyeah": "mockyeah.netlify.app",
   "modbot": "modbotjs.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://ozzyczech.github.io/mock-to-openapi/

> The site content is a web tool and npm package (mock-to-openapi) for converting JSON mock objects to OpenAPI schemas and is relevant to JavaScript developers specifically because it is a JavaScript/TypeScript CLI tool and library published on npm that helps developers generate OpenAPI definitions from JSON examples