### PR TITLE
llmdict.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1874,6 +1874,7 @@ var cnames_active = {
   "livevalidate": "thedhanawada.github.io/LiveValidateJS",
   "lizzy": "stoyan.github.io/Lizzy.js",
   "llama-ui": "olegshulyakov.github.io/llama.ui",
+  "llmdict": "aditya-pola.github.io/llmdict",
   "lmadactyl": "hosting.gitbook.io", // noCF
   "localize": "localize.github.io",
   "localsync": "noderaider.github.io/localsync", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
**llmdict.js.org** — An open-source browsable dictionary of 254 LLM/transformer terms with a stacked card UI, graph view, and LaTeX math rendering. Built with vanilla JS,  
  no framework.                                                                                                                                                             
                                                                                                                                                                              
  Live: https://aditya-pola.github.io/llmdict/
  Repo: https://github.com/aditya-pola/llmdict