### PR TITLE
scrimstracker.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2927,6 +2927,7 @@ var cnames_active = {
   "scrollery": "scrollery.netlify.app",
   "scrollmirror": "scrollmirror.netlify.app",
   "scrollyvideo": "dkaoster.github.io/scrolly-video",
+  "scrimstracker": "swiftal13.github.io/scrims-tracker",
   "scsaver": "hamalt.github.io/scsaver",
   "sdg": "faylearn.github.io/sdgs",
   "sdh": "sdh.netlify.app",


### PR DESCRIPTION
**URL to repository:** https://github.com/Swiftal13/scrims-tracker

**URL to demo/project:** https://swiftal13.github.io/scrims-tracker/

A Minecraft server status tracker for na.scrims.network. Displays live player count, server status, and hourly player count history graph.