### PR TITLE
extension.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1109,7 +1109,7 @@ var cnames_active = {
   "expressad": "flweber.github.io/express-ad-basicauth",
   "expressdynamichelpers": "marvnet.github.io/express-dynamic-helpers-patch",
   "exprtk": "mmomtchev.github.io/exprtk.js",
-  "extension": "extensionjs.mintlify.app",
+  "extension": "cname.mintlify-dns.com", // noCF
   "extension-sprint": "extension-sprint.github.io/home",
   "extenso": "theuves.github.io/extenso.js.org",
   "extraction": "rse.github.io/extraction", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Follow-up to #11129. See https://github.com/js-org/js.org/pull/11129#issuecomment-4275963272 for the loop report.

I tracked it down: the loop only shows up through the proxy (`server: cloudflare`), so the CF layer is the culprit. Switching the entry to `cname.mintlify-dns.com` with `// noCF`, same pattern `docs.webpack` uses on line 906.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://extensionjs.mintlify.app/docs/welcome

> The site content is related to browser extension development and is relevant to JavaScript developers specifically because it's a part of its ecosystem.