### PR TITLE
schematex.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2920,6 +2920,7 @@ var cnames_active = {
   "scene": "daybrush.github.io/scenejs-page",
   "schema": "hosting.gitbook.com",
   "schema-render": "barrior.github.io/schema-render",
+  "schematex": "cname.vercel-dns.com",
   "schemy": "aeberdinelli.github.io/schemy",
   "scopes": "kelleyvanevert.github.io/scopes",
   "scramb": "jastinxyz.github.io/scramb",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2920,7 +2920,7 @@ var cnames_active = {
   "scene": "daybrush.github.io/scenejs-page",
   "schema": "hosting.gitbook.com",
   "schema-render": "barrior.github.io/schema-render",
-  "schematex": "cname.vercel-dns.com",
+  "schematex": "cname.vercel-dns.com", // noCF
   "schemy": "aeberdinelli.github.io/schemy",
   "scopes": "kelleyvanevert.github.io/scopes",
   "scramb": "jastinxyz.github.io/scramb",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://schematex.dev

> The site content is SchemaTex, a zero-dependency JavaScript/TypeScript npm library that renders professional industry-standard diagrams (genograms, pedigrees, IEC 61131-3 ladder logic, IEEE 315 single-line diagrams, phylogenetic trees, circuit schematics, and more) from a concise text DSL, and is relevant to JavaScript developers specifically because it is published as `npm install schematex` with pure SVG output, full SSR support, tree-shaking, TypeScript strict mode, and zero runtime dependencies, filling a gap in the JS ecosystem for standards-compliant diagram rendering.