### PR TITLE
sqlboot.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3115,6 +3115,7 @@ var cnames_active = {
   "spyter": "cname.vercel-dns.com", // noCF
   "sql": "sql-js.github.io/sql.js",
   "sql2struct": "ymlair.github.io/sql2struct",
+  "sqlboot": "cname.vercel-dns.com", // noCF
   "sqlchart": "sqlchart.github.io/sqlchart",
   "squeak": "bertfreudenberg.github.io/SqueakJS",
   "squid": "squidjs.github.io/squid",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://sqlboot.vercel.app/

> The site content is documentation for sqlboot, an npm CLI that bootstraps a local Oracle XE and SQL*Plus development workflow using Docker, Oracle Instant Client, rlwrap, and helper commands.
and is relevant to JavaScript developers specifically because sqlboot is distributed as an npm command-line tool and helps JavaScript/Node.js developers quickly set up a local Oracle database environment for projects that need SQL*Plus, Oracle XE, or database-backed development workflows.
