### PR TITLE
spotistats.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3134,7 +3134,7 @@ var cnames_active = {
   "splitting": "shshaw.github.io/Splitting",
   "spotify": "backtrackapp.github.io/spotify.js",
   "spotify-api": "spotifyapidocs.netlify.app",
-  "spotistats": "spotistats-app.netlify.app",
+  "spotistats": "spotistats.otbeaumont.me",
   "spread": "spreadjs.github.io",
   "spreadsheet": "chiefofgxbxl.github.io/Spreadsheet.js",
   "spring": "hosting.gitbook.com",


### PR DESCRIPTION
Domain was originally added by me in #4130.

The code is still open source and in the same GitHub repository [oscartbeaumont/spotistats](https://github.com/oscartbeaumont/spotistats) I am just trying to centralise management of all my web projects so I want to migrate the hosting.

Nothing about the project is changing.

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://spotistats.js.org or https://spotistats.otbeaumont.me