### PR TITLE
gettic.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1289,6 +1289,7 @@ var cnames_active = {
   "get": "get-js-org.dns.huangxin.org", // noCF
   "getdot": "enderandfiredev.github.io/getdot",
   "getlink": "ilovecode1.github.io/linkjs", // noCF? (don´t add this in a new PR)
+  "gettic": "darking053official.github.io/gettic",
   "ghapi": "haydennyyy.github.io/node-ghapi",
   "ghastly": "hkwu.github.io/ghastly",
   "ghost-shell": "andreyantipov.github.io/ghost-shell",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/darking053official/gettic

> The site content is the official documentation for my open-source Node.js library and is relevant to JavaScript developers specifically because it provides comprehensive API references, installation guides, and modular utility tools to help developers enhance their JavaScript projects.