### PR TITLE
grv-panel.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1292,6 +1292,7 @@ var cnames_active = {
   "getdot": "enderandfiredev.github.io/getdot",
   "getlink": "ilovecode1.github.io/linkjs", // noCF? (don´t add this in a new PR)
   "gettic": "darking053official.github.io/gettic",
+  "grv-panel": "grvofcgarena-tw.github.io",
   "ghapi": "haydennyyy.github.io/node-ghapi",
   "ghastly": "hkwu.github.io/ghastly",
   "ghost-shell": "andreyantipov.github.io/ghost-shell",


### PR DESCRIPTION
- [x] I have read and agree to the [JS.ORG Terms and Conditions](https://js.org/terms/).
- [x] My website is directly related to the JavaScript ecosystem.
- [x] My website contains substantive content and is not a placeholder.
- [x] My website does not automatically redirect away from the js.org domain.

**Subdomain:** grv-panel
**Content URL:** https://grv-panel.eu.org
**Description:** A management dashboard for Discord bots built with Node.js, providing logging and administrative tools for the JavaScript community.

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

⚠️ Before continuing, your site content MUST be DIRECTLY related to the JavaScript ecosystem/community
Using JavaScript on your website is not justification by itself for requesting a subdomain from JS.ORG
You must explain why your website content, not the code, is specifically relevant to other JavaScript developers

📝 Please read and complete the following steps to correctly submit your request:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is ... and is relevant to JavaScript developers specifically because ...
