### PR TITLE
davfinder.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -766,6 +766,7 @@ var cnames_active = {
   "datenel": "astrian.github.io/datenel-doc",
   "dativejs": "dativejs.github.io",
   "davet": "egecelikci.github.io/davet",
+  "davfinder": "davfinder.pages.dev",
   "dawn": "dawnelixir.github.io/dawn.js.org",
   "dawood": "mohamedawood.github.io/Dawood",
   "day": "dayjs.github.io/website",


### PR DESCRIPTION
Add davfinder.js.org

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://davfinder.pages.dev/?server=https://webdav-demo.pages.dev/&username=demo&password=demo

> The site content is a live demo of the `davfinder` NPM package and is relevant to JavaScript developers specifically because it provides a ready-to-use Vue 3 and TypeScript component for integrating WebDAV file management into front-end applications.

---
- GitHub: https://github.com/ixiumu/davfinder
- NPM: https://www.npmjs.com/package/davfinder