### PR TITLE
repo-guestabc.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2811,6 +2811,7 @@ var cnames_active = {
   "repeater": "repeaterjs.github.io/repeater",
   "repl": "snowflyt.github.io/repl",
   "replay": "edbentley.github.io/replay",
+  "repo-guestabc": "gustavo111336.github.io",
   "reqoal": "aldhosutra.github.io/reqoal",
   "reqsrv": "axtk.github.io/reqsrv",
   "request": "request.gitbooks.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://gustavo111336.github.io/Gerenciador/gen.html

> The site content is a JavaScript-based neon system simulator and it is relevant to JavaScript developers specifically because it implements Service Workers for offline capabilities and complex custom DOM manipulation logic.
