### PR TITLE
dairy.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -741,6 +741,7 @@ var cnames_active = {
   "d-patterns": "alias.zeit.co", // noCF
   "d4": "joelburget.github.io/d4",
   "daily.tmr": "tmr-daily.netlify.app", // noCF
+  "dairy": "yamanweb1.github.io/bethany-hamilton",
   "daisy": "warengonzaga.github.io/daisy.js",
   "daksh0225": "daksh0225.github.io",
   "damo": "damodharanj.github.io",


### PR DESCRIPTION
Adding dairy.js.org pointing to yamanweb1.github.io/bethany-hamilton

- Site is live at https://yamanweb1.github.io/bethany-hamilton/
- CNAME file is in the repo
- GitHub Pages is built and configured with the custom domain