### PR TITLE
Add rgatu-guide.js.org subdomain

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2838,6 +2838,7 @@ var cnames_active = {
   "rexs": "uellenberg.github.io/REXS",
   "reyes": "michaelbreyes.github.io/reyes",
   "rgbstrip": "xrealneon.github.io/RGBStrip",
+  "rgatu-guide": "calladius.github.io/rgatu-guide",
   "rickdesantis": "rickdesantis.github.io",
   "riffy": "cname.vercel-dns.com", // noCF
   "riiickyy": "riiickyy.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://calladius.github.io/rgatu-guide/

> The site content is an interactive PWA campus guide for Rybinsk State Aviation Technical University (РГАТУ) with SVG floor maps, department directory, and offline support. It is relevant to JavaScript developers specifically because it demonstrates building a full-featured PWA with vanilla JavaScript, interactive SVG manipulation, Service Worker caching strategies, and mobile-first responsive design — all without frameworks.