### PR TITLE
Add js-leadmachine.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1656,6 +1656,9 @@ var cnames_active = {
   "js-utils": "teneplaysofficial.github.io/js-utils-kit",
   "js2lua": "xiangnanscu.github.io/js2lua", // noCF
   "jscord": "thepoptartcrpr.github.io/jscord",
+  "jscord": "thepoptartcrpr.github.io/jscord",
+  "js-leadmachine": "NileGazer00.github.io/NileGazer00-js-leadmachine",
+  "jsdec": "liulihaocai.github.io/JSDec",
   "jsdec": "liulihaocai.github.io/JSDec",
   "jsfe": "jsfe.netlify.app",
   "jslabs": "cname.vercel-dns.com", // noCF

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1654,11 +1654,9 @@ var cnames_active = {
   "js-fixerr": "anujsinghwd.github.io/js-fixerr",
   "js-labs": "cname.vercel-dns.com", // noCF
   "js-utils": "teneplaysofficial.github.io/js-utils-kit",
-  "js2lua": "xiangnanscu.github.io/js2lua", // noCF
-  "jscord": "thepoptartcrpr.github.io/jscord",
+    "js2lua": "xiangnanscu.github.io/js2lua", // noCF
   "jscord": "thepoptartcrpr.github.io/jscord",
   "js-leadmachine": "NileGazer00.github.io/NileGazer00-js-leadmachine",
-  "jsdec": "liulihaocai.github.io/JSDec",
   "jsdec": "liulihaocai.github.io/JSDec",
   "jsfe": "jsfe.netlify.app",
   "jslabs": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
js-leadmachine

NileGazer00.github.io/NileGazer00-js-leadmachine

Content URL: https://NileGazer00.github.io/NileGazer00-js-leadmachine

**Content explanation:**
LeadGen.js is a free, open-source JavaScript lead generation tool. The site provides a 40-line vanilla JS snippet that captures leads to Google Sheets, a live interactive JavaScript console demo, and professional JS development services (React/Node.js, $100-150/hr).

 [x] Reasonable content
 [x] Terms and conditions