### PR TITLE
Added `japkgen.js.org`

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1693,6 +1693,7 @@ var cnames_active = {
   "jwjawa": "cmdjwj.github.io",
   "jwt-autorefresh": "cchamberlain.github.io/jwt-autorefresh", // noCF? (don´t add this in a new PR)
   "jwtonline": "boneyt92.github.io/jwtonline",
+  "japkgen": "japkgen.opendnf.cloud",
   "kafka": "tulios.github.io/kafkajs",
   "kaguwo": "kaguwos-portfolio.netlify.app",
   "kahoot": "na-west1.surge.sh",


### PR DESCRIPTION
* [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
* [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
* The site content can be seen at https://japkgen.opendnf.cloud/

> The site content is a documentation and homepage website for JAPKGEN, an open-source Android APK/project generator CLI built with JavaScript and Node.js.
>
> JAPKGEN provides templates and tooling for generating Android projects such as WebView apps, native apps, Kotlin projects, Jetpack Compose apps, and web framework integrations.
>
> The project is relevant to JavaScript developers specifically because it is part of the Node.js ecosystem, distributed as a JavaScript CLI tool, and intended for developers who build Android applications and automation tools using JavaScript technologies.
