### PR TITLE
Update cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1180,6 +1180,7 @@ var cnames_active = {
   "flare": "nsaunders.github.io/flare",
   "flaregram": "adityash4rma.github.io/flaregram-website",
   "flash": "flashcardjs.github.io",
+  "flashcut": "flash-cutt.netlify.app",
   "flatpickr": "flatpickr.github.io",
   "flavor": "blackmirror1980.github.io/flavor-js",
   "fld-grd": "mrksbnch.github.io/fld-grd",


### PR DESCRIPTION
Add flashcut.js.org

[x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org#no-content))
[x] I have read and accepted the [Terms and Conditions](https://github.com/js-org/js.org#terms-and-conditions)

- The site content can be seen at https://flash-cutt.netlify.app

The site content is a custom web application and is relevant to JavaScript developers specifically because it showcases frontend development, custom UI components, and JavaScript logic.