### PR TITLE
piratetv.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2515,7 +2515,8 @@ var cnames_active = {
   "pinipig": "jmdisuanco.github.io/pinipig",
   "pino-nest": "yamcodes.github.io/pino-nestjs",
   "pinyin": "hotoo.github.io/pinyin",
-  "pipes": "pipesjs.github.io", // noCF? (don´t add this in a new PR)
+  "pipes": "pipesjs.github.io", // noCF? (don´t add this in a new PR),
+    "piratetv": "activistpt.github.io/pirate-tv-clone",
   "pivot": "wnda.github.io/pivot",
   "pivotgrid": "iskandr1.github.io/Pivot",
   "pivottable": "nicolaskruchten.github.io/pivottable",


### PR DESCRIPTION
## Add piratetv.js.org

**Subdomain:** piratetv.js.org
**Target:** activistpt.github.io/pirate-tv-clone

Pirate TV - IPTV streaming site with Portuguese channels, news, and movies.