### PR TITLE
mova.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2162,6 +2162,7 @@ var cnames_active = {
   "mosaic": "tilework.github.io/mosaic.js.org",
   "mostage": "mirmousaviii.github.io/mostage",
   "motion-live": "cname.vercel-dns.com", // noCF
+  "mova": "cname.vercel-dns.com", // noCF
   "mp": "cncdn.github.io",
   "mp3tag": "eidoriantan.github.io/mp3tag.js",
   "mpe": "weareroli.github.io/mpejs", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
I'd like to request the subdomain mova.js.org for my open-source video downloader project called Mova. It's a Next.js project hosted on Vercel.

Project repo: https://github.com/Stonepath-dotcom/gutsytik
Live site: https://movadl.vercel.app