### PR TITLE
paypertool

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2464,6 +2464,7 @@ var cnames_active = {
   "pathtrace": "kovacsv.github.io/WebGLPathTrace", // noCF? (don´t add this in a new PR)
   "pax": "nathan.github.io/pax",
   "payment-crypto": "kiogia.github.io/payment-crypto",
+  "paypertool": "web-production-d8897.up.railway.app",
   "pc": "jeffpar.github.io/pc",
   "pcl": "cname.vercel-dns.com", // noCF
   "pdf": "iamcristye.github.io/PDF",


### PR DESCRIPTION
Hi! Requesting `paypertool.js.org` for **PayPerTool** — an open-source x402 payment protocol service that sells AI-agent tools per HTTP call in USDC on Base mainnet.

- **Target:** `web-production-d8897.up.railway.app`
- **GitHub:** https://github.com/paypertool/paypertool-app
- **npm:** https://www.npmjs.com/package/@paypertooldev/paypertool-mcp (with provenance)
- **Built in:** TypeScript / Node / Express / React / Vite

The project is the resource server + landing page + MCP client (Node CLI on npm) that lets AI agents pay $0.0005–$0.02 per tool call via the x402 protocol. Entirely JavaScript/TypeScript stack, fully open source (MIT).

Confirming I've read the README and that the target URL serves the project's homepage, not a redirect. Thanks!