### PR TITLE
mamafa.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1954,6 +1954,7 @@ var cnames_active = {
   "maker": "microsoft.github.io/maker.js",
   "makes": "makesjs.github.io",
   "mali": "malijs.github.io",
+  "mamafa": "mazhenhai-gif.github.io/mamafa-jsorg",
   "mangascrape": "tzurs11.github.io/MangaScrape",
   "manic": "manicjs.github.io",
   "mansiart": "mansiart.github.io/mansiart",


### PR DESCRIPTION
I would like to add mamafa.js.org for a JavaScript testing page hosted on GitHub Pages.

The site provides a simple JavaScript interaction demo and is used to test JavaScript behavior, static deployment, and JS.ORG domain routing.

Target:
https://mazhenhai-gif.github.io/mamafa-jsorg/

Checklist:
- [x] The site content is related to JavaScript
- [x] The target is hosted on GitHub Pages
- [x] I understand and accept the JS.ORG terms