### PR TITLE
paypertool.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2464,6 +2464,7 @@ var cnames_active = {
   "pathtrace": "kovacsv.github.io/WebGLPathTrace", // noCF? (don´t add this in a new PR)
   "pax": "nathan.github.io/pax",
   "payment-crypto": "kiogia.github.io/payment-crypto",
+  "paypertool": "web-production-d8897.up.railway.app",
   "pc": "jeffpar.github.io/pc",
   "pcl": "cname.vercel-dns.com", // noCF
   "pdf": "iamcristye.github.io/PDF",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://web-production-d8897.up.railway.app/

> PayPerTool is an open-source x402 payment protocol service that lets AI agents pay per HTTP call in USDC on Base mainnet. The site is the public-facing resource server and landing page that documents 12 priced JavaScript-callable tools (web scraping, search, extraction, summarization, agent memory, etc.) discoverable via a JSON catalog at /api/tools. It includes interactive npx install instructions for the companion MCP client (Node CLI), a live status dashboard at /status that polls the JS-built API, plus Terms and Privacy pages. It is relevant to the JavaScript community because (1) both the server and the client are TypeScript/Node, (2) the npm package @paypertooldev/paypertool-mcp (published with provenance from GitHub Actions) is the primary integration path for JS-based AI agents, MCP clients, and LangChain.js workflows, and (3) it implements an emerging open web standard (x402, originally proposed by Coinbase) for machine-to-machine micropayments over HTTP, which is directly useful for any JS developer building autonomous agents. Repository: https://github.com/paypertool/paypertool-app · npm: https://www.npmjs.com/package/@paypertooldev/paypertool-mcp