### PR TITLE
discord-player.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -857,7 +857,7 @@ var cnames_active = {
   "discord-mini-games": "tanvishgg.github.io/Discord-Mini-Games.js",
   "discord-moderator": "xyligan-gp.github.io/discord-moderator",
   "discord-music-player": "sushibtw.github.io/discord-music-player",
-  "discord-player": "androz2091.github.io",
+  "discord-player": "androz2091.github.io/discord-player",
   "discord-portable-player": "lolollllo.github.io/discord-portable-player",
   "discord-rankup": "x404dev.github.io/discord-rankup",
   "discord-sensei": "demonicious.github.io/discord-sensei",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -857,7 +857,7 @@ var cnames_active = {
   "discord-mini-games": "tanvishgg.github.io/Discord-Mini-Games.js",
   "discord-moderator": "xyligan-gp.github.io/discord-moderator",
   "discord-music-player": "sushibtw.github.io/discord-music-player",
-  "discord-player": "cname.vercel-dns.com", // noCF
+  "discord-player": "androz2091.github.io", // noCF
   "discord-portable-player": "lolollllo.github.io/discord-portable-player",
   "discord-rankup": "x404dev.github.io/discord-rankup",
   "discord-sensei": "demonicious.github.io/discord-sensei",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -857,7 +857,7 @@ var cnames_active = {
   "discord-mini-games": "tanvishgg.github.io/Discord-Mini-Games.js",
   "discord-moderator": "xyligan-gp.github.io/discord-moderator",
   "discord-music-player": "sushibtw.github.io/discord-music-player",
-  "discord-player": "androz2091.github.io", // noCF
+  "discord-player": "androz2091.github.io",
   "discord-portable-player": "lolollllo.github.io/discord-portable-player",
   "discord-rankup": "x404dev.github.io/discord-rankup",
   "discord-sensei": "demonicious.github.io/discord-sensei",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://discord-player.js.org

> The site content is the official documentation for discord-player, a Node.js library for building Discord music bots, and is relevant to JavaScript developers specifically because it documents a widely used npm package (188K downloads in the past year) and shows how to add audio streaming and playback to their Discord apps.

This is an existing subdomain, not a new request. We are only moving the target from Vercel to GitHub Pages:

  "discord-player": "cname.vercel-dns.com"  ->  "discord-player": "androz2091.github.io"

Repo: https://github.com/Androz2091/discord-player

One thing: when I set the custom domain on GitHub Pages, GitHub reports discord-player.js.org as already taken and asks to verify it. Per #7815, could you confirm it isn't allocated elsewhere and help with the verification step?