### PR TITLE
mongez.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2150,6 +2150,7 @@ var cnames_active = {
   "monaco-tailwindcss": "monaco-tailwindcss.netlify.app",
   "monaco-unified": "monaco-unified.netlify.app",
   "monaco-yaml": "monaco-yaml.netlify.app",
+  "mongez": "hassanzohdy.github.io/mongez-docs",
   "monkberry": "monkberry.github.io",
   "mono": "mono-js.github.io/mono",
   "monocle": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://hassanzohdy.github.io/mongez-docs/

> The site content is documentation for the @mongez/* ecosystem — 25 standalone TypeScript packages published to npm, covering state management (atom, react-atom, atomic-query), HTTP and caching, React forms / router / helmet, i18n, build tooling (vite, pkgist), CLI utilities (copper), and AI coding agent integration (agent-kit) — and is relevant to JavaScript developers specifically because every package targets npm consumers, all sources are MIT-licensed on github.com/hassanzohdy, and the docs ship a /llms-full.txt aggregate so AI coding agents can consume the full TypeScript API surface in one fetch.

> **Note for reviewers:** the github.io preview URL above renders without styling because Astro's site config targets the apex mongez.js.org domain — asset URLs are root-relative which 404 under the /mongez-docs/ subpath. The full HTML content is present in the page source. Once this PR is merged and DNS propagates, the styled version will be live at mongez.js.org.