### PR TITLE
ailcr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -130,6 +130,7 @@ var cnames_active = {
   "ahooks-v2": "ahooks-v2.surge.sh",
   "aider": "tjz101.github.io/aider-js-pages",
   "aiga": "cname.vercel-dns.com", // noCF
+  "ailcr": "cname.vercel-dns.com", // noCF
   "air": "openwebstudio.github.io/Air-Docs",
   "airesearch": "vtempest.github.io/ai-research-agent",
   "airtable-plus": "victorhahn.github.io/airtable-plus",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://ailcr.vercel.app

> The site content is a landing page and live routing console for AI-LCR (AI Least Cost Routing), an open-source TypeScript/JavaScript npm package that routes LLM API calls to the cheapest available provider in real time — supporting OpenAI, Anthropic, Google Gemini, OpenRouter, and more — with automatic fallback, real-time cost tracking, and a visual routing table. It is relevant to JavaScript developers specifically because it is an npm package (published as `ai-lcr`) for Node.js and TypeScript projects that need to integrate multiple LLM providers and minimize API costs without vendor lock-in; the site includes installation instructions, provider comparison tables, and Vercel AI SDK integration examples.

> **Note on naming:** `ailcr` is the natural abbreviation of the GitHub repository name `ai-lcr` (`victorzhrn/ai-lcr`), with the hyphen omitted for a cleaner subdomain.