### PR TITLE
yadavjipdf.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3797,6 +3797,7 @@ var cnames_active = {
   "y2j": "ultirequiem.github.io/y2j",
   "y86": "quietshu.github.io/y86", // noCF? (don´t add this in a new PR)
   "yadl": "yadljs.github.io",
+  "yadavjipdf": "cname.vercel-dns.com", // noCF
   "yagolopez": "yagolopez.github.io",
   "yak": "cname.vercel-dns.com", // noCF
   "yaka": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
## Domain Registration

- **Domain:** yadavjipdf.js.org
- **Purpose:** Free Online PDF Toolkit - Merge, Split, Compress & Convert PDFs  
- **Made in India** 🇮🇳
- **Website:** https://yadavjipdf-5lav.vercel.app/
- **GitHub:** https://github.com/by028812-code/yadavjipdf
- **Developed by:** Brijesh Yadav
- **CNAME:** cname.vercel-dns.com (Vercel hosted)

### About
YadavjiPDF is a free, open-source PDF toolkit built with Next.js. It provides 8 tools: Merge, Split, Compress, Image-to-PDF, Word-to-PDF, Excel-to-PDF, PDF-to-Word, and PDF-to-Excel. All processing happens server-side with complete data privacy.