### PR TITLE
unit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3455,6 +3455,7 @@ var cnames_active = {
   "unicorn": "mirai-explorer.github.io/unicorn",
   "unicornly": "unicornly.github.io/unicornly",
   "unique-session": "molaga.github.io/unique-session",
+  "unit": "cname.vercel-dns.com", // noCF
   "universal-api": "raxjs.github.io/universal-api",
   "unle": "lochyj.github.io/unle",
   "uno": "theatom06.github.io/uno.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page.
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms-and-conditions).
- The site content can be seen at https://unit-thk.vercel.app/

> The site content is documentation and product pages for `@coreify/unit`, a JavaScript and TypeScript package for unit conversion, parsing, formatting, mixed measurements, and localization support. It includes install instructions, API references, examples, supported units, and usage details for developers evaluating or integrating package. It is relevant to JavaScript developers specifically because it documents an npm package built for JavaScript and TypeScript applications, helping developers use conversion utilities in Node.js, browser apps, libraries, and modern JS tooling workflows.