### PR TITLE
envx.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -660,6 +660,7 @@ var cnames_active = {
   "core-ln": "runcitadel.github.io/core-ln.ts",
   "coreact": "coreactjs.github.io/coreact",
   "coredi": "empla.github.io/coredi",
+  "coreify-env": "cname.vercel-dns.com", // noCF
   "coreutils": "ultirequiem.github.io/coreutils",
   "cork": "davej.github.io/CorkJS",
   "corki": "dvtate.github.io/corki",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1044,8 +1044,8 @@ var cnames_active = {
   "energy": "energychain.github.io/energy",
   "englishell": "tzador.github.io/englishell",
   "enn": "loganpaxton.github.io/enn",
-  "envx": "cname.vercel-dns.com", // noCF
   "envshh": "sanjib-sen.github.io/envshh",
+  "envx": "cname.vercel-dns.com", // noCF
   "epi": "epispot.github.io/EpiJS",
   "epicker": "eling486.github.io/EPicker-docs",
   "eplayer": "132yse.github.io/eplayer",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1045,6 +1045,7 @@ var cnames_active = {
   "energy": "energychain.github.io/energy",
   "englishell": "tzador.github.io/englishell",
   "enn": "loganpaxton.github.io/enn",
+  "envx": "cname.vercel-dns.com", // noCF
   "envshh": "sanjib-sen.github.io/envshh",
   "epi": "epispot.github.io/EpiJS",
   "epicker": "eling486.github.io/EPicker-docs",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -660,7 +660,6 @@ var cnames_active = {
   "core-ln": "runcitadel.github.io/core-ln.ts",
   "coreact": "coreactjs.github.io/coreact",
   "coredi": "empla.github.io/coredi",
-  "coreify-env": "cname.vercel-dns.com", // noCF
   "coreutils": "ultirequiem.github.io/coreutils",
   "cork": "davej.github.io/CorkJS",
   "corki": "dvtate.github.io/corki",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://envx-thk.vercel.app/

> The site content is documentation for @coreify/envx, covering environment variable loading, validation, config-file setup, CLI usage, and safe runtime patterns for JavaScript projects, and it is relevant to JavaScript developers specifically because the package was renamed from coreify-env to envx to give it a clearer standalone identity, move beyond old branding, and better match its expanded scope for configuring Node.js and bundler-based apps safely.