### PR TITLE
coreify-env.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -665,7 +665,6 @@ var cnames_active = {
   "core-ln": "runcitadel.github.io/core-ln.ts",
   "coreact": "coreactjs.github.io/coreact",
   "coredi": "empla.github.io/coredi",
-  "coreify-env": "cname.vercel-dns.com", // noCF
   "coreutils": "ultirequiem.github.io/coreutils",
   "cork": "davej.github.io/CorkJS",
   "corki": "dvtate.github.io/corki",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://coreify-env.js.org

> The site content is documentation for `@coreify/envx`, covering environment variable loading, validation, config-file setup, CLI usage, and safe runtime patterns for JavaScript projects, and it is relevant to JavaScript developers specifically because the package was renamed from `coreify-env` to `envx`, so the old `coreify-env` js.org entry is being removed and replaced with the new project name that now matches the published package, docs, and developer-facing APIs.
