### PR TITLE
gz-metro-mbti.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1403,6 +1403,7 @@ var cnames_active = {
   "gyps": "huijari.github.io/Gyps",
   "gyre": "wridder.github.io/GyreJS", // noCF? (don´t add this in a new PR)
   "gyx": "yourtion.github.io/gyx.js.org",
+  "gz-metro-mbti": "1151785600-hue.github.io/gz-metro-personality",
   "h": "makenowjust.github.io/h.js",
   "h3": "h3rald.github.io/h3",
   "h7ml": "h7ml.github.io/web",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://1151785600-hue.github.io/gz-metro-personality/

> The site content is a Guangzhou Metro personality test web app (inspired by MBTI/VBTI), built with React + Vite + Tailwind CSS. It is relevant to JavaScript developers specifically because it is a fully client-side SPA showcasing modern JavaScript tooling (React hooks, Canvas API for radar charts, Vite build system) and is open source at https://github.com/1151785600-hue/gz-metro-personality.