### PR TITLE
Add tag-spider-x.js.org subdomain

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3306,6 +3306,7 @@ var cnames_active = {
   "tab": "gdmcc.github.io/tab",
   "tabs": "mehrizi.github.io/tabs",
   "tagscript": "cname.vercel-dns.com", // noCF
+  "tag-spider-x": "tag-spider-x.netlify.app",
   "tagster": "goschevski.github.io/tagster", // noCF? (don´t add this in a new PR)
   "taha": "orcxzjeeeee.github.io/taha",
   "tailwind-baseline": "apkoponen.github.io/tailwind-baseline-site",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://tag-spider-x.netlify.app

> The site content is a landing page for a JavaScript-powered Discord bot called Tag Spider. The bot is built using JavaScript and tracks Discord server tag status in real time. It notifies server members about tag availability and changes using JavaScript-based APIs and webhooks. This is directly relevant to the JavaScript developer community as it showcases a practical JavaScript bot application integrated with the Discord API.