### PR TITLE
Add tag-spider-x.js.org subdomain

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3306,6 +3306,7 @@ var cnames_active = {
   "tab": "gdmcc.github.io/tab",
   "tabs": "mehrizi.github.io/tabs",
   "tagscript": "cname.vercel-dns.com", // noCF
+  "tag-spider-x": "tag-spider-x.netlify.app",
   "tagster": "goschevski.github.io/tagster", // noCF? (don´t add this in a new PR)
   "taha": "orcxzjeeeee.github.io/taha",
   "tailwind-baseline": "apkoponen.github.io/tailwind-baseline-site",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://tag-spider-x.netlify.app

> The site content is a landing page for a JavaScript-powered Discord bot called Tag Spider. The bot tracks Discord server tag status in real time using JavaScript and the Discord API. It notifies server members instantly about tag availability and changes through JavaScript-based webhooks and event listeners. This project is directly relevant to JavaScript developers as it demonstrates practical JavaScript integration with the Discord API for real-time event tracking and notification systems.