### PR TITLE
coreify.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -665,6 +665,7 @@ var cnames_active = {
   "core-ln": "runcitadel.github.io/core-ln.ts",
   "coreact": "coreactjs.github.io/coreact",
   "coredi": "empla.github.io/coredi",
+  "coreify": "cname.vercel-dns.com", // noCF
   "coreutils": "ultirequiem.github.io/coreutils",
   "cork": "davej.github.io/CorkJS",
   "corki": "dvtate.github.io/corki",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms-and-conditions)
- The site content can be seen at https://coreify.vercel.app/

> The site content is package hub for Coreify organization with docs and links for JavaScript and TypeScript utilities published under the Coreify scope on npm. and is relevant to JavaScript developers specifically because page helps developers discover packages, read examples, open repositories, and use utilities for env validation, unit conversion, graph work, currency formatting, and localized date handling.