### PR TITLE
Add 'cakgup' to cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -477,6 +477,7 @@ var cnames_active = {
   "caicai": "qianxunclub.github.io/CaiCai",
   "caissa": "agentx-cgn.github.io/caissa",
   "caizhiyuannn": "caizhiyuannn.github.io",
+  "cakgup": "cakgup.github.io",
   "calcium": "courageous-bublanina-6857c1.netlify.app",
   "calcy": "odevlord.github.io/Calcy", // noCF? (don´t add this in a new PR)
   "calisto": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://cakgup.github.io

> The site content is my personal software engineering portfolio and frontend layout showcase, and is relevant to JavaScript developers specifically because it demonstrates interactive web implementations, clean UI architecture, and modern JavaScript structures that serve as an open-source reference for the developer community.