### PR TITLE
whitebored.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3739,6 +3739,7 @@ var cnames_active = {
   "which-node": "tobysmith568.github.io/which-node-js",
   "whistle": "whistle-lang.github.io/website",
   "whiteboard": "yhozen.github.io/whiteboard",
+  "whitebored": "whiteboard-app-v77u.onrender.com",
   "whoasked": "mathdebate09.github.io/who-asked",
   "wi": "rstee.serv00.net",
   "wice": "yulioaj290.github.io/wice.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page
- [x] I have read and accepted the [Terms and Conditions](https://github.com/js-org/js.org/blob/master/TERMS_AND_CONDITIONS.md)

- The site content can be seen at https://whiteboard-app-v77u.onrender.com

> The site content is a real-time collaborative whiteboard web application where multiple users draw together on an infinite canvas with live cursors, presence, comments and chat, and is relevant to JavaScript developers specifically because it is a full-stack JavaScript project (React + Vite frontend, Node.js + Express + Socket.IO backend) demonstrating real-time WebSocket synchronization that other JS developers can learn from and reference.

Requested subdomain: `whitebored.js.org` → CNAME target `whiteboard-app-v77u.onrender.com` (custom domain already configured on the host). Source: https://github.com/Jeql88/whiteboard-app