### PR TITLE
printable-tools-lab.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2592,6 +2592,7 @@ var cnames_active = {
   "preset": "awesome-starter.github.io/website",
   "pretty-print-json": "center-key.github.io/pretty-print-json",
   "prettylog": "moosecoop.github.io/PrettyLog",
+  "printable-tools-lab": "printable-tools-lab.pages.dev", // noCF
   "printx": "x-ext.netlify.app",
   "pristine": "sha256.github.io/Pristine", // noCF
   "producify": "jesobreira.github.io/producify",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://printable-tools-lab.pages.dev/

> The site content is PrintableTools Lab, a free browser-based JavaScript utility site with no-upload PDF tools, local image tools, QR generators, and printable document generators. It is relevant to JavaScript developers specifically because the product demonstrates practical client-side JavaScript workflows for PDF manipulation, canvas image processing, QR generation, structured-data exports, local-first privacy, static deployment, and API-free utility design. The source repository is https://github.com/yanqr213/printable-tools-lab and the live app runs as a static JavaScript application on Cloudflare Pages.