### PR TITLE
standard-tool.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3199,6 +3199,7 @@ var cnames_active = {
   "stamps": "ronald-baars.github.io/stamps",
   "stampy": "stampylongr.github.io",
   "standard-resource": "hosting.gitbook.com", // noCF
+  "standard-tool": "finom.github.io/standard-tool",
   "stapp": "tinkoffcreditsystems.github.io/stapp",
   "starfield": "annikav9.github.io/starfield.js",
   "starify-discord": "dastormer.github.io/starify-discord",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/finom/standard-tool

> The site content is the documentation and reference implementation for `standard-tool`, a zero-dependency type for defining portable LLM tools, and is relevant to JavaScript developers specifically because it standardizes how JavaScript and TypeScript libraries, SDKs, and frameworks define LLM tool definitions across model providers.

The page is a GitHub Pages site (source `main` /`docs`) rendering the project README and an overview; the repository's `CNAME` file already contains `standard-tool.js.org`, so it will serve at https://standard-tool.js.org/ once the subdomain DNS is created.
