### PR TITLE
Add openthymos.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2404,6 +2404,7 @@ var cnames_active = {
   "openkey": "microlinkhq.github.io/openkey",
   "opennext": "opennextjs.github.io/docs",
   "openrecord": "philwaldmann.github.io/openrecord",
+  "openthymos": "gryszzz.github.io/open-thymos",
   "opentrivia-guide": "turtlepaw.github.io/trivia-docs",
   "opentype": "nodebox.github.io/opentype.js",
   "opk": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
### Subdomain request
`openthymos` → `gryszzz.github.io/open-thymos`

- [x] There is reasonable content on the page.
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms.html).

- The site content can be seen at https://gryszzz.github.io/open-thymos/

> The site content is the documentation and web frontend for OpenThymos, an open-source execution runtime for AI agents, and is relevant to JavaScript developers specifically because the project ships a TypeScript/Next.js web application alongside a three.js-powered documentation site, and targets JavaScript/TypeScript agent tooling.