### PR TITLE
beat.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -353,6 +353,7 @@ var cnames_active = {
   "beaga": "beagajs.github.io/beaga",
   "beamwind": "kenoxa.github.io/beamwind",
   "bear": "bytexiong.github.io/VitePress.BearPlatform",
+  "beat": "mackushev.github.io/metronome",
   "beatzoid": "beatzoid.github.io",
   "bedstack": "cname.vercel-dns.com", // noCF
   "bee": "beejsdev.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://mackushev.github.io/metronome/

> The site content is a free open-source browser metronome (https://github.com/mackushev/metronome) — a fully client-side TypeScript web app built on the Web Audio API: a lookahead click scheduler against the precise AudioContext clock, on-the-fly oscillator click synthesis, per-beat accents/mutes, subdivisions, and a speed trainer — and is relevant to JavaScript developers specifically because it demonstrates accurate audio timing in JavaScript (the "A Tale of Two Clocks" scheduling pattern) and serves as a working, documented reference of Web Audio scheduling and SVG-based interactive UI without frameworks, with the full source published for the JS community.