### PR TITLE
Add handschrift.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1420,6 +1420,7 @@ var cnames_active = {
   "han": "han-js.hanlu.im", // noCF
   "hana": "romantic-kare-c84899.netlify.app",
   "hanan": "hanandito.github.io/teddypicker",
+  "handschrift": "tomhenniger.github.io/text-to-lac",
   "hapi-sol": "yonjah.github.io/hapi-sol",
   "hapin": "ha-pin.github.io",
   "happy": "e24.github.io/happy", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/tomhenniger/text-to-lac

> The site content is "Handschrift", a free and open-source suite of pen-plotter tools built entirely in vanilla JavaScript (no server, no build step): it captures real handwriting as a single-line vector font — including a fully client-side JS image pipeline with perspective correction, Zhang-Suen skeletonization and path tracing for scanned paper templates — writes arbitrary text with per-letter variation, converts images into plottable line art (hatching, squiggle, spiral, ASCII art) and generates .lac project files in the browser via a hand-written JavaScript ZIP writer. It is relevant to JavaScript developers specifically because the site IS the application: an openly licensed JS codebase demonstrating canvas rendering, browser-based image processing and binary file generation that developers can use, study and contribute to. The GitHub Pages deployment (gh-pages for repo tomhenniger/text-to-lac) already carries the CNAME file for handschrift.js.org, which is why the github.io URL currently redirects; the rendered content can be verified in the repository or as soon as DNS is active.