### PR TITLE
baymin.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -343,6 +343,7 @@ var cnames_active = {
   "bathtiles": "laurenyoo.github.io/website-bathtiles.js", // noCF
   "battle-city": "shinima.github.io/battle-city",
   "battlerite": "dragory.github.io/battlerite.js",
+  "baymin": "cname.vercel-dns.com", // noCF
   "bb": "bbtalkjs.github.io",
   "bbn": "jammer99.github.io/bbn",
   "bc": "mazko.github.io/bc.js",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://baymin.vercel.app

> The site content is Baymin, a free English–Japanese business communication web app offering tone-aware JP↔EN translation, a paragraph polisher, and a business phrase reference, and is relevant to JavaScript developers specifically because it is a production, open-to-all example of a modern JavaScript stack (Next.js 16 App Router, React 19, TypeScript) and serves JavaScript developers who work with Japanese teams and clients and need correct workplace Japanese.

Note: target is Vercel (`cname.vercel-dns.com`, noCF); the domain `baymin.js.org` is already attached to the Vercel project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)