### PR TITLE
nova.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2330,6 +2330,7 @@ var cnames_active = {
   "notibar": "duyetdev.github.io/notibar.js",
   "notion-cms": "cname.vercel-dns.com", // noCF
   "nougat": "nougatlang.github.io",
+  "nova": "chezburgar.github.io/nova-browser",
   "novasheets": "novasheets.netlify.app",
   "now": "leodog896.github.io/jsnow",
   "noypi": "noypi.alwaysdata.net",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://chezburgar.github.io/nova-browser/

> The site content is the homepage, download page and developer documentation for Nova, an open-source web browser built with JavaScript on Electron, and is relevant to JavaScript developers specifically because it documents the project's architecture, source layout and build-from-source steps so developers can study, fork and contribute to it — see the developer docs at https://chezburgar.github.io/nova-browser/developers.html