### PR TITLE
mdsvr.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2028,6 +2028,7 @@ var cnames_active = {
   "mdcdev": "galleniz.github.io/mdcdev.js",
   "mdjs": "xtnmoe.github.io/MdJs",
   "mdld": "davay42.github.io/mdld-parse",
+  "mdsvr": "satoshiman.github.io/mdsvr",
   "mdxe": "cname.vercel-dns.com", // noCF
   "mechan": "dusterthefirst.github.io/mechan.js",
   "medan": "medan-js.github.io", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://satoshiman.github.io/mdsvr/

> The site content is documentation for **mdsvr** — a zero-config Node.js CLI tool that serves Markdown/MDX files as a full-featured documentation website. It is relevant to JavaScript developers specifically because it is an npm package (`npm install mdsvr`) built for the Node.js/JS ecosystem, targeting JS developers who need to quickly spin up documentation sites from Markdown files without any configuration.