### PR TITLE
feria-jaguar.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1156,6 +1156,7 @@ var cnames_active = {
   "feature-u": "kevinast.github.io/feature-u",
   "feeble": "feeblejs.github.io/feeble",
   "fela": "cname.vercel-dns.com", // noCF
+  "feria-jaguar": "hays05.github.io/feria-jaguar",
   "festercluck": "festercluck.github.io", // noCF? (don´t add this in a new PR)
   "fetch-json": "center-key.github.io/fetch-json",
   "fetch-the-parrot": "fetch-the-parrot.netlify.app",


### PR DESCRIPTION
Adding feria-jaguar.js.org


- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://hays05.github.io/feria-jaguar/

> The site content is an open-source vanilla-JavaScript educational web app (a browser-based voice assistant called Jago) and it is relevant to JavaScript developers specifically because it is a complete real-world example of building a voice-enabled chat assistant in the browser using the Web Speech API, the Fetch API and the Gemini API, with public source code others can learn from and reuse.
