### PR TITLE
pixiv.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2535,7 +2535,7 @@ var cnames_active = {
   "pivottable": "nicolaskruchten.github.io/pivottable",
   "pixelanimator": "grough.github.io/pixel-animator",
   "pixelart": "meriadec.github.io/PixelartJS", // noCF? (don´t add this in a new PR)
-  "pixiv": "cname.vercel-dns.com", // noCF
+  "pixiv": "pixiv.js.org.pages.dnsoe5.com", // noCF
   "pixpact": "legendsayantan.github.io/pixpact",
   "pizzle": "pizzlejs.github.io",
   "plain-blog": "weareoutman.github.io/plain-blog",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://pixiv-one.wjghj.cn/

> The site content is for illustration appreciation and is relevant to JavaScript developers specifically because it includes a reusable Pixiv SDK, encapsulated within a TypeScrip framework.

This request is to update an existing site. Migrate from Vercel to EdgeOne. GitHub repo: [FreeNowOrg/PixivNow](https://github.com/FreeNowOrg/PixivNow), CNAME: [CNAME](https://github.com/FreeNowOrg/PixivNow/tree/master/CNAME)