### PR TITLE
popper.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3882,4 +3882,3 @@ var cnames_active = {
    * <3
    */
 }
-

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2569,7 +2569,6 @@ var cnames_active = {
   "pong-zh": "xiaozhu2021.github.io/javascript-pong",
   "pools": "phederal.github.io/pools",
   "popcorn-api": "nirewen.github.io/popcorn-api",
-  "popper": "fezvrasta.github.io/popper.js",
   "popup": "simondmc.github.io/popup-site",
   "portafolio-web": "velazquezadrian.github.io/Portafolio-web",
   "portafolioalejandrarobles": "alerobles3.github.io/portafolioalejandrarobles",
@@ -3883,3 +3882,4 @@ var cnames_active = {
    * <3
    */
 }
+

--- a/records_restricted.js
+++ b/records_restricted.js
@@ -257,3 +257,17 @@ var cnames_restricted = [
     "www(1/2/3/42)",
     "xml"
 ]
+
+/*
+ **** RETURNED SUBDOMAINS
+ * ****************************
+ *
+ * The following subdomains were previously active but have been returned
+ * by their owners. They are restricted to prevent domain squatting.
+ *
+ */
+
+var cnames_returned = [
+    "popper" // formerly fezvrasta.github.io/popper.js — project moved to dedicated domain
+]
+

--- a/records_restricted.js
+++ b/records_restricted.js
@@ -259,15 +259,15 @@ var cnames_restricted = [
 ]
 
 /*
- **** RETURNED SUBDOMAINS
+ **** RETIRED SUBDOMAINS
  * ****************************
  *
- * The following subdomains were previously active but have been returned
- * by their owners. They are restricted to prevent domain squatting.
+ * The following subdomains were previously active but have been retired
+ * They are restricted to prevent domain squatting.
  *
  */
 
-var cnames_returned = [
-    "popper" // formerly fezvrasta.github.io/popper.js — project moved to dedicated domain
+var cnames_retired = [
+    "popper" // #627
 ]
 


### PR DESCRIPTION
Closes the request from @indus in #627.

The project originally at `popper.js.org` has since moved to a dedicated domain (`floating-ui.com`). As requested, this PR:

- Removes `popper` from `cnames_active.js`
- Adds `popper` to a new `cnames_returned` section in `records_restricted.js` to prevent domain squatting

Thanks for your patience and for maintaining JS.ORG!