### PR TITLE
fazz.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1151,6 +1151,7 @@ var cnames_active = {
   "faux": "fauxos.github.io",
   "favicon": "kaerez.github.io/favicon",
   "favium": "cname.vercel-dns.com", // noCF
+  "fazz": "cname.vercel-dns.com", // noCF
   "fcanvas": "fcanvas.github.io/docs",
   "fcbosque": "cronopio.github.io/fcbosque", // noCF? (don´t add this in a new PR)
   "fe": "xcss.github.io/FE",


### PR DESCRIPTION
**Subdomain:** fazz.js.org
**Target:** cname.vercel-dns.com (`// noCF` — hosted on Vercel)

FAZZ is a full-stack attendance-management web application built with **Next.js 16 + React 19 + TypeScript** (QR check-in, role-based dashboards, Excel import/export). The subdomain is already configured on the Vercel project, so it will serve content over HTTPS as soon as the CNAME goes live.

- [x] Added to the bottom-most position alphabetically appropriate in `cnames_active.js`
- [x] Target is a valid CNAME; marked `// noCF` because Vercel must not sit behind the Cloudflare proxy
- [x] The site is functional and contains content