### PR TITLE
periplum.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2494,6 +2494,7 @@ var cnames_active = {
   "penpow": "penpow.github.io",
   "pentris": "justinjc.github.io/pentris2", // noCF? (don´t add this in a new PR)
   "pereira": "pereirajs.github.io/pagina",
+  "periplum": "periplum.github.io/periplum.js.org",
   "permissions": "danielnewell.github.io/permissions",
   "persian-tools": "persian-tools.github.io/persian-tools",
   "personalkanban": "nishantpainter.github.io/personal-kanban",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://periplum.github.io/periplum.js.org/

> The site content is the homepage and documentation for Periplum, an open-source MIT-licensed JavaScript library (https://github.com/periplum/periplum-core) that renders interactive chronological "history maps" on top of Leaflet. It is relevant to JavaScript developers specifically because it documents the library's JavaScript API and configuration options, shows live examples built with it, and gives a copy-paste `<script>` integration snippet plus a project template that JS developers use to build their own maps.
