### PR TITLE
Add new entry for 'resumin' in cnames_active.js

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2842,6 +2842,7 @@ var cnames_active = {
   "resume": "xaoxuu.github.io/resume.js.org",
   "resume-builder": "blopa.github.io/Resume-Builder",
   "resumebuilder": "resumebuilder-dracu.netlify.app",
+  "resumin": "resume-bc7b1.web.app",  
   "retalk": "cname-china.vercel-dns.com", // noCF
   "rete": "retejs.github.io",
   "reto": "awmleer.github.io/reto",


### PR DESCRIPTION
- [ ✅] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [ ✅] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://resume-bc7b1.web.app/>
- working profile can be seen at <https://resume-bc7b1.web.app/johndoe>

> Resumin is a platform that helps JavaScript developers create and host live, continuously updated resumes and portfolio pages. Developers can showcase their JavaScript projects, GitHub repositories, open source contributions, technical skills, work experience, and education through a personalized public profile. The platform is specifically useful to JavaScript developers because it provides an easy way to maintain a professional developer profile that automatically reflects their latest work and contributions, helping them share their experience with employers, collaborators, and the wider JavaScript community.
