### PR TITLE
xlsanal.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3797,6 +3797,7 @@ var cnames_active = {
   "xhemj": "xhemj.now.sh", // noCF
   "xhy": "xhy.github.io",
   "xi102": "xi102.github.io",
+  "xlsanal": "xlsanal.github.io/js",
   "xiangqiz": "xiangqiz.github.io/Hello",
   "xiangyue": "fzxx.github.io/XiangYue",
   "xiaolan": "mcxiaolan.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <https://xlsanal.github.io/js>

> The site content is a personal portfolio showcasing open-source JavaScript tools, advanced Discord.js security bots, and Node.js backend automation scripts, and is relevant to JavaScript developers specifically because it shares architecture details, custom log modules, and open-source contributions within the JS ecosystem.