### PR TITLE
noteplus.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2329,6 +2329,7 @@ var cnames_active = {
   "notebook": "wugenqiang.github.io/NoteBook",
   "noted": "carter-slade.github.io/Noted-", // noCF? (don´t add this in a new PR)
   "notepad": "amitmerchant1990.github.io/notepad",
+  "noteplus": "cname.vercel-dns.com", // noCF
   "nothing": "cbtak.github.io/nothing",
   "notibar": "duyetdev.github.io/notibar.js",
   "notion-cms": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Add noteplus subdomain

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://note-plus-mu.vercel.app

> The site content is a PWA-enabled modern online text editor with OS-level file handling capabilities, and is relevant to JavaScript developers specifically because it serves as an open-source tool built to demonstrate web-based ecosystem integrations (like the Web File Handling API) within client-side JavaScript applications.