### PR TITLE
brickbuild.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -44,6 +44,7 @@ var cnames_active = {
   "101": "7anshuai.github.io/js101", // noCF? (don´t add this in a new PR)
   "131": "netrvin.github.io",
   "140513": "140513.github.io",
+  "brickbuild": "brickbuild-site.github.io/js.org",
   "1auth": "1auth.pages.dev",
   "1c": "oknosoft.github.io/1c",
   "1diaboliko84": "1diaboliko84.github.io",


### PR DESCRIPTION

add brickbuild website
its a game sandbox which will be able to be playable soon
can be visited here: https://brickbuild-site.github.io/js.org/


- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at <link>

> The site content is ... and is relevant to JavaScript developers specifically because ...
