### PR TITLE
scope.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2957,6 +2957,7 @@ var cnames_active = {
   "schema-render": "barrior.github.io/schema-render",
   "schematex": "cname.vercel-dns.com", // noCF
   "schemy": "aeberdinelli.github.io/schemy",
+  "scope": "geeheon.github.io/scope",
   "scopes": "kelleyvanevert.github.io/scopes",
   "scramb": "jastinxyz.github.io/scramb",
   "scramble": "ignatiusmb.github.io/scramble",


### PR DESCRIPTION
- [x] There is reasonable content on the page, with this not being a placeholder/coming-soon/under-construction page
- [x] I have read and accepted the [Terms and Conditions](https://github.com/js-org/js.org/blob/master/CONTRIBUTING.md)

- The requested subdomain is `scope.js.org`
- The site content can be seen at https://geeheon.github.io/scope/

> The site content is an open-source, single-file vanilla-JavaScript web application that runs entirely client-side on GitHub Pages with no backend, and it is relevant to JavaScript developers specifically because the entire tool ships as browser JavaScript and demonstrates in-browser HTML5-canvas geometry editing plus client-side generation of text/script files, all without any server component.
