### PR TITLE
valitype.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3596,6 +3596,7 @@ var cnames_active = {
   "validator": "ppoffice.github.io/validator.js", // noCF? (don´t add this in a new PR)
   "valine": "xcss.github.io/valine",
   "valirator": "massive-angular.github.io/valirator",
+  "valitype": "fontebasso.github.io/valitype",
   "valobot": "misly16.github.io/ValoBotsite",
   "value-enhancer": "crimx.github.io/value-enhancer",
   "vanessa": "vanessa219.github.io/vanessa",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://fontebasso.github.io/valitype

> The site content is the API reference and usage documentation for valitype, a zero-dependency npm package published under the MIT license, and is relevant to JavaScript developers specifically because it documents runtime validation of environment variables for Node.js applications, covering TypeScript types, built-in validators, and structured error handling patterns used in servers, CLI tools, and configuration loaders.  