### PR TITLE
loopy.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1918,6 +1918,7 @@ var cnames_active = {
   "longlast": "benchristel.github.io/longlast",
   "loog": "israelroldan.github.io/loog",
   "lookup": "lookup-js-org.pages.dev",
+  "loopy": "kmjnnhyk.github.io/loopy",
   "lostyle": "rtsao.github.io/lostyle",
   "lottiefy": "pd4d10.github.io/lottiefy",
   "loxt": "loxt.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://kmjnnhyk.github.io/loopy/ — note: the GitHub Pages custom domain is already configured to `loopy.js.org`, so this URL currently 301-redirects until DNS activates. Site source (Astro + Starlight, deployed via Actions): https://github.com/kmjnnhyk/loopy/tree/master/website

> The site content is the documentation site for **loopy** (https://github.com/kmjnnhyk/loopy), an open-source type-safe TypeScript DSL for building LLM agents, tools, workflows, and multi-agent teams — around 45 pages of API reference, core-concept explainers, and guides in English and Korean. It is relevant to JavaScript developers specifically because it documents a TypeScript/JavaScript library for the Node.js ecosystem: the docs teach JS/TS developers the library's API surface, type-inference behavior, and agent-composition patterns.