### PR TITLE
gamezone.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1272,6 +1272,7 @@ var cnames_active = {
   "gamedevcontestal": "fromdenisvieira.github.io/gamedevcontestal", // noCF? (don´t add this in a new PR)
   "gametime": "parking-master.github.io/Gametime.js",
   "gametracker": "officialpiyush.github.io/gametracker.js",
+  "gamezone": "pupkaneo.github.io/just-games",
   "gamingnet": "gamingmineblox.github.io/GamingNet",
   "garlic-team": "garlic-team.github.io/website",
   "gathertown": "warengonzaga.github.io/gathertown.js",


### PR DESCRIPTION
Добавляю домен `gamezone.js.org` для моего игрового портала.

Сайт: https://pupkaneo.github.io/just-games/
Репозиторий: https://github.com/pupkaneo/just-games

Проект содержит игры на JavaScript:
- Угадай число
- Камень-ножницы-бумага
- Крестики-нолики
- Кликер

Соответствует правилам JS.ORG (Terms of Service).