### PR TITLE
lumiworld.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1935,6 +1935,7 @@ var cnames_active = {
   "lukemetoki": "luke2m.github.io",
   "lume.shiraha": "importantimport.github.io/lume_theme_shiraha", // noCF
   "lumi": "furioustsunami.github.io/lumijs",
+  "lumiworld": "k3234.github.io/Lumiword",
   "lumpia": "lumpiajs.netlify.app",
   "lunisolar": "waterbeside.github.io/lunisolar-docs",
   "lunox": "kodepandai.github.io/lunox",


### PR DESCRIPTION
## 子域名申请

**请求域名**: `lumiworld.js.org`
**GitHub Page**: `k3234.github.io/Lumiword`
**仓库**: https://github.com/k3234/Lumiword

### 项目简介

LumiWorld 是一个将学科学习与角色扮演游戏深度融合的教育平台。前端使用 JavaScript（Canvas 2D + Three.js 3D），通过浏览器运行游戏化学习体验。

- **答题即战斗** — 答对攻击，答错防御，用知识战胜怪物
- **双端渲染** — 2D 像素风（Canvas + JavaScript）+ 3D 场景（Three.js）自由切换
- **AI 驱动** — NPC 对话 / 题目生成 / 语音合成均由 AI 提供
- **学科覆盖** — 数学、物理、化学、生物、英语

### CNAME 文件

已在仓库根目录添加 `CNAME` 文件，内容为 `lumiworld.js.org`。
GitHub Pages 已配置自定义域名 `lumiworld.js.org`。

© 2026 Lumi by Kai

<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

⚠️ Before continuing, your site content MUST be DIRECTLY related to the JavaScript ecosystem/community
Using JavaScript on your website is not justification by itself for requesting a subdomain from JS.ORG
You must explain why your website content, not the code, is specifically relevant to other JavaScript developers

📝 Please read and complete the following steps to correctly submit your request:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements

-->

- [x] There is reasonable content on the page (see: `https://github.com/js-org/js.org/wiki/No-Content`)
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://k3234.github.io/Lumiworld/

> The site content is a gamified learning platform (LumiWorld) that combines education with RPG gameplay, where students battle monsters by answering subject questions, and is relevant to JavaScript developers specifically because the entire frontend is built with JavaScript technologies (Canvas 2D API for pixel-art rendering and Three.js for 3D scene rendering), the project serves as a practical example of building browser-based games with vanilla JavaScript and popular JS libraries, and the site provides interactive JavaScript-powered educational content (dynamic NPC dialogues, AI-driven question generation, and real-time canvas animations) that demonstrates advanced JavaScript development patterns for the JS community.

