### PR TITLE
linked-markdown.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1877,6 +1877,7 @@ var cnames_active = {
   "ling": "wangziling.github.io",
   "linghucong": "jiji262.github.io",
   "link-styler": "sheikhoo.github.io/link-styler",
+  "linked-markdown": "wazootech.github.io/linked-markdown-ts",
   "linkify": "hypercontext.github.io/linkifyjs",
   "linksharer": "linksharer.github.io/linksharer.js.org",
   "lion": "ing-bank.github.io/lion",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://wazootech.github.io/linked-markdown-ts/

> The site content is a landing page for the Linked Markdown TypeScript library, which provides structured frontmatter extraction (YAML, JSON, TOML) and RDF data support for markdown documents, and it is relevant to JavaScript developers specifically because it is a TypeScript library published on JSR that enables JavaScript/TypeScript developers to parse and work with linked data in markdown documents.