### PR TITLE
tidewatch.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3409,6 +3409,7 @@ var cnames_active = {
   "thundercats": "thundercatsjs.github.io/thundercats", // noCF? (don´t add this in a new PR)
   "tictactoe": "jeff-tian.github.io/tic-tac-toe-ai",
   "tiden": "tidenjs.netlify.app",
+  "tidewatch": "tidewatchi.vercel.app",
   "tidy": "tidy-js.github.io",
   "tik": "nascjoao.github.io/tikjs",
   "tile": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
## Add tidewatch.js.org

- **Target:** tidewatchi.vercel.app (Vercel)
- **Site:** https://tidewatchi.vercel.app — TideWatch, an open-source crypto market tracker (React + Vite), real-time prices via Binance WebSocket, plain-language market summaries, PWA + Telegram Mini App.
- **Repo:** https://github.com/difik-hub/TideWatch

- [x] The site content is related to a JavaScript project (open-source React app, repo above)
- [x] The site is reachable and shows meaningful content
- [x] I have added the CNAME entry in alphabetical order