### PR TITLE
evenout.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1104,6 +1104,7 @@ var cnames_active = {
   "euclid": "anandthakker.github.io/euclid", // noCF? (don´t add this in a new PR)
   "eva": "eva-engine.github.io",
   "eval": "jshawl.github.io/eval", // noCF? (don´t add this in a new PR)
+  "evenout": "shubham-safaya.github.io/evenout",
   "event-storage": "albe.github.io/node-event-storage",
   "eventstore": "adrai.github.io/node-eventstore", // noCF? (don´t add this in a new PR)
   "everything": "ajays97.github.io/Everything.js",


### PR DESCRIPTION
Requesting `evenout.js.org` → `shubham-safaya.github.io/evenout`.

EvenOut is a free, open-source, ad-free JavaScript web app (vanilla JS SPA + PWA) for splitting group expenses with friends — live at https://shubham-safaya.github.io/evenout/ with source at https://github.com/Shubham-Safaya/evenout.

- [x] The site content is already reachable at the target
- [x] JavaScript project (vanilla JS single-page app, service worker, supabase-js)
- [x] I will add the CNAME file / custom domain once the record is active