### PR TITLE
effect-graphql.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1009,6 +1009,7 @@ var cnames_active = {
   "ecstar": "ecstar-js.github.io/Ecstar",
   "ed2k": "sunnyli.github.io/ed2k.js",
   "ef": "classicoldsong.github.io/ef.js.org",
+  "effect-graphql": "egriff38.github.io/effect-graphql",
   "effectful": "awto.github.io/effectfuljs",
   "effects": "effectsjs.github.io/effectsjs",
   "eggsy": "eggsywashere.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://egriff38.github.io/effect-graphql/

> The site content is the auto-generated API reference for [`effect-graphql`](https://www.npmjs.com/package/effect-graphql) (an npm package that derives a GraphQL schema and runtime from Effect `Schema` types), rendered by [@effect/docgen](https://github.com/Effect-TS/docgen) with the just-the-docs theme, and is relevant to JavaScript developers specifically because it documents the public surface of a TypeScript/JavaScript library built on the Effect ecosystem, with typechecked usage examples per exported function alongside signatures and version information.
