### PR TITLE
nextspatial.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2282,6 +2282,7 @@ var cnames_active = {
   "next-qrcode": "next-qrcode.github.io",
   "next-redux-cookie-wrapper": "bjoluc.github.io/next-redux-cookie-wrapper",
   "next-share": "next-share.github.io",
+  "nextspatial": "nextspatial.workers.dev",
   "next.awesome-vue": "awesome-vue.netlify.app", // noCF
   "nextkit-fetcher": "ultirequiem.github.io/nextkit-fetcher",
   "nextqr": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Requesting nextspatial.js.org

This domain will be used for the Urban Research Radar project, a JavaScript-based web application built with React, Vite, and Cloudflare Workers.

Repository:
https://github.com/sondve/urban-research-radar

Target:
nextspatial.workers.dev

- [x] There is reasonable content on the page (see: No Content)
- [x] I have read and accepted the Terms and Conditions