### PR TITLE
pure-photos-ai.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2652,7 +2652,7 @@ var cnames_active = {
   "pulumi-pretty": "maddijoyce.github.io/pulumi-pretty",
   "puppet": "anandchowdhary.github.io/puppet",
   "pure": "fengzilong.github.io/pure",
-  "pure-photos-ai": "grupoclip.github.io/pure-photos-ai",
+  "pure-photos-ai": "grupoclip.github.io/pure-photos-ai-web",
   "purplet": "purpletjs.netlify.app",
   "pushoo": "imaegoo.github.io/pushoo",
   "pusu": "xliudaxia.github.io/pusu-ui",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2652,6 +2652,7 @@ var cnames_active = {
   "pulumi-pretty": "maddijoyce.github.io/pulumi-pretty",
   "puppet": "anandchowdhary.github.io/puppet",
   "pure": "fengzilong.github.io/pure",
+  "pure-photos-ai": "grupoclip.github.io/pure-photos-ai",
   "purplet": "purpletjs.netlify.app",
   "pushoo": "imaegoo.github.io/pushoo",
   "pusu": "xliudaxia.github.io/pusu-ui",


### PR DESCRIPTION
**Site:** https://grupoclip.github.io/pure-photos-ai/ (live, CNAME file already in place on the gh-pages branch)

**Target:** grupoclip.github.io/pure-photos-ai

Landing page for Pure Photos AI, an open-source iOS app (repo: https://github.com/grupoclip/pure-photos-ai). The page itself is a hand-built HTML/CSS/JS site with an interactive JS-driven demo.

Thanks for the great service!