### PR TITLE
jz.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1713,6 +1713,7 @@ var cnames_active = {
   "jwjawa": "cmdjwj.github.io",
   "jwt-autorefresh": "cchamberlain.github.io/jwt-autorefresh", // noCF? (don´t add this in a new PR)
   "jwtonline": "boneyt92.github.io/jwtonline",
+  "jz": "dy.github.io/jz",
   "kafka": "tulios.github.io/kafkajs",
   "kaguwo": "kaguwos-portfolio.netlify.app",
   "kahoot": "na-west1.surge.sh",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://dy.github.io/jz/

> The site content is the landing page, in-browser REPL, examples and benchmarks for jz — an ahead-of-time compiler for the numeric core of JavaScript (DSP, audio, math, parsers) to lean GC-free WASM ([dy/jz](https://github.com/dy/jz)) — and is relevant to JavaScript developers specifically because it compiles the JS they already write (valid jz is valid JS: no type annotations, no runtime) and lets them try the compiler live in the REPL and compare output against JS engines in the benchmarks.
