### PR TITLE
hayao.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1440,7 +1440,6 @@ var cnames_active = {
   "hasura-om": "mrspartak.github.io/hasura-om",
   "hawiah": "cname.vercel-dns.com", // noCF
   "hay": "hayjs.github.io/hay.js.org",
-  "hayao": "hellojanpacan.github.io/hayao.js.org",
   "hbase": "adaltas.github.io/node-hbase-docs",
   "hcs": "kimcore.github.io/hcs.js", // noCF
   "heartseekers": "rajington.github.io/heartseekers", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://hayao.js.org

> The site content is moved to its own domain (https://hayao.dev/docs/), the js.org page has been a plain redirect since the move, and I'd like to retire the subdomain entirely. It is relevant to JavaScript developers specifically because it is an existing JS.org subdomain.

Please remove the `hayao` subdomain — I'm the owner (the target repo is mine: hellojanpacan/hayao.js.org). Thanks for the service over its lifetime!