### PR TITLE
edge-aura.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1009,6 +1009,7 @@ var cnames_active = {
   "eco": "quick-eco.netlify.app",
   "ecstar": "ecstar-js.github.io/Ecstar",
   "ed2k": "sunnyli.github.io/ed2k.js",
+  "edge-aura": "cname.vercel-dns.com", // noCF
   "ef": "classicoldsong.github.io/ef.js.org",
   "effect-graphql": "egriff38.github.io/effect-graphql",
   "effectful": "awto.github.io/effectfuljs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://edge-aura-xi.vercel.app

> The site content is the documentation and interactive demo site for [edge-aura](https://github.com/takuyajodai/edge-aura), an open-source JavaScript/TypeScript library published on npm ([`edge-aura`](https://www.npmjs.com/package/edge-aura)) that renders an organic, Siri-style glow around the screen edges using a zero-dependency Canvas 2D engine, with a React adapter. The page lets developers try the effect live, tune every option (palette, band width, corner rounding, tap response) with instant feedback, and copy working install/usage snippets — and is relevant to JavaScript developers specifically because it documents and demonstrates a JS library they can install and use in their own web apps.
