### PR TITLE
bullwatch.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -449,6 +449,7 @@ var cnames_active = {
   "bud": "roots-bud.netlify.app",
   "bui": "kjantzer.github.io/bui",
   "builders": "cname.vercel-dns.com", // noCF
+  "bullwatch": "hrithik-infinite.github.io/bullwatch",
   "bullwinkle": "bullwinkle.github.io",
   "bun": "the94air.github.io/bun",
   "bundle": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://hrithik-infinite.github.io/bullwatch/

> The site content is a live, interactive demo of **bullwatch**, an open-source observability dashboard for [BullMQ](https://github.com/taskforcesh/bullmq) — the popular Redis-backed job queue for Node.js. The whole dashboard runs client-side in the browser (queues, live metrics, latency histograms, dead-letter analysis, deploy markers, alerts, payload search and masking), so visitors can click through the real product with simulated data. It is relevant to JavaScript developers specifically because it is a developer tool for the Node.js/JavaScript backend ecosystem: BullMQ is a JavaScript library, and this page helps JS developers evaluate and understand a monitoring tool for their JS job queues.