### PR TITLE
vectorless.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3639,6 +3639,7 @@ var cnames_active = {
   "vbuild": "egoist.github.io/vbuild",
   "vdcs": "hopae-official.github.io/Verifiable-Digital-Credentials",
   "ve-table": "xiguaxigua.github.io/ve-table",
+  "vectorless": "vectorless-js.pages.dev",
   "vega": "cname.vercel-dns.com", // noCF
   "velite": "zce.github.io/velite",
   "velt": "veltjs.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://vectorless-js.pages.dev

> The site content is the documentation for [vectorless-js](https://www.npmjs.com/package/vectorless-js), a published npm package that does retrieval-augmented generation without embeddings: it builds a table-of-contents tree from a document and lets an LLM navigate it with tools, instead of chunking, embedding, and vector search. It is relevant to JavaScript developers specifically because it is a JS/TypeScript library they would install and use. The docs are written for that audience: a quick start that runs as a Bun script, a full TypeScript API reference covering the exported types and functions, a page on browser usage that explains why the WASM parser needs its module passed in and why a browser cannot call an LLM provider directly, a storage page, an end-to-end walkthrough, and a runnable example project. The library runs in the browser via WASM and anywhere else JS runs, and it is a JavaScript port of [PageIndex](https://github.com/VectifyAI/PageIndex) (MIT), with its tree builder verified byte-for-byte against the Python original.

The custom domain is already configured on the Cloudflare Pages project, so it should resolve as soon as the CNAME exists. The site serves directly at the subdomain with no redirects away from js.org.