### PR TITLE
identicraft.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1530,7 +1530,7 @@ var cnames_active = {
   "id": "andae.github.io/id",
   "id.single-spa": "single-spa.github.io/id.single-spa.js.org", // noCF
   "id3": "jeff-tian.github.io/id3",
-  "identicraft": "cname.vercel-dns.com", // noCF
+  "identicraft": "itsshiroharu.github.io",
   "idettman": "idettman.github.io",
   "idmp": "ha0z1.github.io/idmp",
   "ienumerable": "mbasso.github.io/ienumerable",


### PR DESCRIPTION
<!--

Thanks for creating a pull request to request a new subdomain from JS.ORG

⚠️ Before continuing, your site content MUST be DIRECTLY related to the JavaScript ecosystem/community
Using JavaScript on your website is not justification by itself for requesting a subdomain from JS.ORG
You must explain why your website content, not the code, is specifically relevant to other JavaScript developers

📝 Please read and complete the following steps to correctly submit your request:

- Ensure that your pull request changes only the cnames_active.js file, adding a single new line for your subdomain request
  - Follow the existing format established by the other entries, a new line with the subdomain as the key and the target hostname as the value
  - Add your new line to the file in alphabetical order, and follow the guidance given by the comments in the file itself

- Fill out this pull request template in your pull request description, maintaining the format provided to you
  - Tick the two checkboxes, agreeing to the sentences, below by placing an x inside the square brackets ([ ] becomes [x])
  - Add a link (GitHub repository, Vercel deployment, etc.), so we can review your site
  - Explain what your site content is and how it relates to the JavaScript community/ecosystem, so we can validate your request

- Ensure that your site content follows the content requirements set out in our README: https://github.com/js-org/js.org#content-requirements

-->

- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [here](https://identicraft.shiroharu.eu.org). 

> The site content is a landing page for Identicraft, a JavaScript-based Minecraft avatar rendering library, CLI, and serverless API. The aim for this project is to be the definitive, developer-friendly toolkit for Minecraft avatar rendering. Whether any developer or users need a URL (via Vercel Deployment), a command, or a function call. ``identicraft.js.org`` will now serve as landing pages, and documentation will be redirected to my main page. Related PR: #10555 

- Repository can be seen at [here](https://github.com/itsshiroharu/Identicraft).
Side Note: The site domain provided above is temporary and will be changed immediately once the change is approved.

Changing the Deployment for the Project from Vercel to GitHub Pages due to the demo pages/deployment (which uses ``identicraft.js.org``) has been flooded with millions of Edge Request. In short: Abused. Thus, my account on vercel is now locked (for this month), and returns with 402 error.

And as for the demo (e.g. ``https://identicraft.js.org/api/avatar/username/512``) will be unavailable and any user or developer that wants to try the project must either deploy to vercel themselves, or uses CLI or function call as stated in the documentations.