### PR TITLE
ytz-arrivals.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3869,6 +3869,7 @@ var cnames_active = {
   "youtube-lite": "9oelm.github.io/youtube-lite",
   "yt-dislikes-viewer": "pgamerx.github.io/yt-dislikes-viewer",
   "yt-quota-manager": "arnav-kr.github.io/yt-quota-manager",
+  "ytz-arrivals": "mustafasyed13.github.io/billy-bishop-arrivals",
   "yu": "yuxizhe.github.io/yu",
   "yuko": "notmarx.github.io/Yuko-Website",
   "yunite": "discify.github.io/yunite.js",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3869,7 +3869,7 @@ var cnames_active = {
   "youtube-lite": "9oelm.github.io/youtube-lite",
   "yt-dislikes-viewer": "pgamerx.github.io/yt-dislikes-viewer",
   "yt-quota-manager": "arnav-kr.github.io/yt-quota-manager",
-  "ytz-arrivals": "mustafasyed13.github.io/billy-bishop-arrivals",
+  "ytz-arrivals": "mustafasyed13.github.io/ytz",
   "yu": "yuxizhe.github.io/yu",
   "yuko": "notmarx.github.io/Yuko-Website",
   "yunite": "discify.github.io/yunite.js",


### PR DESCRIPTION
Requesting **ytz-arrivals.js.org** → `mustafasyed13.github.io/billy-bishop-arrivals`

The site is a live arrivals board for Billy Bishop Toronto City Airport (YTZ): real-time U.S. arrivals with radar-based touchdown detection, a live aircraft map, and a cancellations panel. Static site (HTML/CSS/JS) hosted on GitHub Pages, actively maintained.

- Site content is live and rendering at https://mustafasyed13.github.io/billy-bishop-arrivals/
- A CNAME file containing `ytz-arrivals.js.org` has been added to the repository.