### PR TITLE
labsync.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1802,6 +1802,7 @@ var cnames_active = {
   "lab": "labjs.netlify.app",
   "labelauty": "fntneves.github.io/jquery-labelauty", // noCF? (don´t add this in a new PR)
   "labs": "cname.vercel-dns.com", // noCF
+  "labsync": "ridgotnochill.github.io",
   "labui": "ztl-uwu.github.io/Lab-Design-Guide",
   "lad": "ladjs.github.io/lad",
   "lambda": "lambdajs.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
Requesting **labsync.js.org**.

- **Target:** `ridgotnochill.github.io` (GitHub Pages)
- **Live now at:** https://ridgotnochill.github.io/Labsync/
- **Project:** LabSync — a laboratory management system web app built with **React + TypeScript + Vite + Tailwind CSS**. Dashboards, inventory, equipment, scheduling, and monitoring for a college lab.

Checklist:
- [x] The project is related to the JavaScript ecosystem (React/TypeScript SPA).
- [x] The site has real content (multiple working pages), is not a placeholder or "under construction".
- [x] The target is a valid, reachable host.
- [x] I have read and followed the js.org guidelines.

I'll set the custom domain in the repo's GitHub Pages settings once this is merged. Thanks for maintaining js.org!
