### PR TITLE
senpainet.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3020,6 +3020,7 @@ var cnames_active = {
   "semantic-api": "semantic-api.github.io/docs",
   "semo": "semojs.github.io/semo",
   "senil": "mrfarhad.github.io/senilwebsite",
+  "senpainet": "ykonishi2006.github.io",
   "seoul": "seouljs.github.io/seoul.js.org",
   "sequel": "sequeljs.github.io",
   "sequelize-guard": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
**What is the purpose of the domain?**
SenpaiNet — an anonymous peer-advice web app where students of a school get guidance from their alumni/senior students. It is an open-source single-page app built with vanilla JavaScript, hosted on GitHub Pages.

**Repository:** https://github.com/YKonishi2006/senpainet
**Current URL:** https://ykonishi2006.github.io/senpainet/

- [x] Added `"senpainet": "ykonishi2006.github.io"` to `cnames_active.js` (alphabetical order)
- [x] `CNAME` file with `senpainet.js.org` is present in the target repository
- [x] The site has real, meaningful content (not a placeholder)
