### PR TITLE
krdscn-ui.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1788,7 +1788,7 @@ var cnames_active = {
   "kowalski": "k0walslk1.github.io",
   "kra": "kra-framework.github.io/kra-suite", // noCF
   "krds": "krds-community.github.io/krds-react",
-  "krdscn-ui": "krdscn-ui.github.io",
+  "krdscn-ui": "krdscn-ui.github.io/ui",
   "kremling": "canopytax.github.io/kremling.js.org",
   "krida": "elvisdsz.github.io/krida",
   "kshitij": "kshitij98.github.io",

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1788,6 +1788,7 @@ var cnames_active = {
   "kowalski": "k0walslk1.github.io",
   "kra": "kra-framework.github.io/kra-suite", // noCF
   "krds": "krds-community.github.io/krds-react",
+  "krdscn-ui": "krdscn-ui.github.io",
   "kremling": "canopytax.github.io/kremling.js.org",
   "krida": "elvisdsz.github.io/krida",
   "kshitij": "kshitij98.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://krdscn-ui.github.io/ui/

> The site content is the documentation site, live component catalog, and installable shadcn registry for krdscn-ui, a React/TypeScript UI component library implementing the Korea Government Design System (KRDS) on top of shadcn/ui and is relevant to JavaScript developers specifically because it lets them browse and install accessible KRDS-compliant React components directly through the shadcn CLI in their own JavaScript/TypeScript projects.
