### PR TITLE
monitor-sismico.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2179,6 +2179,7 @@ var cnames_active = {
   "monaco-unified": "monaco-unified.netlify.app",
   "monaco-yaml": "monaco-yaml.netlify.app",
   "mongez": "hassanzohdy.github.io/mongez-docs",
+  "monitor-sismico": "ehyenmanft.github.io/monitor-sismico",
   "monkberry": "monkberry.github.io",
   "mono": "mono-js.github.io/mono",
   "monocle": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://ehyenmanft.github.io/monitor-sismico/

> The site content is an open-source (MIT) real-time seismic monitoring dashboard and is relevant to JavaScript developers specifically because it serves as a documented reference implementation they can fork and adapt: a build-free, single-file Three.js + Leaflet architecture (custom 3D globe, no chart libraries, hand-drawn canvas visualizations, PWA with service worker), and — most importantly — an open JavaScript solution to a data-access problem many civic developers face: Venezuela's seismological agency (FUNVISIS) has no public API, so the repository includes a JS proxy with content-based field validation that normalizes its undocumented, unstable feed. The README (https://github.com/ehyenmanft/monitor-sismico) documents the architecture and step-by-step self-deployment so JS developers can replicate the stack for any country with closed seismic data.
