### PR TITLE
ethoslabs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1106,6 +1106,7 @@ var cnames_active = {
   "eta": "alias.zeit.co", // noCF
   "eth": "eth-js.github.io/eth-dev-tools",
   "ethavatar": "filips123.github.io/EthAvatar.JS",
+  "ethoslabs": "pieda6.github.io/silas-portfolio",
   "euc": "wnda.github.io/euc",
   "euclid": "anandthakker.github.io/euclid", // noCF? (don´t add this in a new PR)
   "eva": "eva-engine.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/Pieda6/silas-portfolio (source repository — the CNAME for ethoslabs.js.org is already in place on the GitHub Pages branch, so the github.io URL currently redirects to the requested subdomain pending this PR)

> The site content is Ethos Labs, a discovery directory where Web3 projects post their pitch and connect with backers, and is relevant to JavaScript developers specifically because it is a fully open-source, no-build-step vanilla JavaScript application intended as a reference implementation: it includes a deterministic canvas generative-art engine, GSAP/ScrollTrigger scroll choreography, and a documented, dependency-vendored codebase JS developers can read and reuse from the linked repository.
