### PR TITLE
netspeed.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2272,6 +2272,7 @@ var cnames_active = {
   "nestjs-toolkit": "globalartinc.github.io/nestjs-toolkit",
   "neteasecloudmusicapi": "w4ctech.github.io/NeteaseCloudMusicApi",
   "neteasecloudmusicapienhanced": "neteasecloudmusicapienhanced.github.io/api-enhanced",
+  "netspeed": "itsmeadarsh2008.github.io/netspeed",
   "neurax-api": "configneurax.netlify.app",
   "neureact": "kasmirawijayathunga.github.io/neureact",
   "neuro": "neurojs.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://itsmeadarsh2008.github.io/netspeed

> The site content is a free, open-source browser-based speed test that measures download/upload speed, ping, jitter, and packet loss using Cloudflare or Ookla servers. It is relevant to JavaScript developers specifically because it is a pure JavaScript application demonstrating modern web capabilities (WebSockets, canvas, service workers) with full source code available on GitHub for reference