### PR TITLE
Add mesopota.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2078,6 +2078,7 @@ var cnames_active = {
   "mesh": "crcn.github.io/mesh.js.org", // noCF? (don´t add this in a new PR)
   "meshesha": "meshesha.github.io",
   "metadata": "oknosoft.github.io/metadata.js",
+  "mesopota": "IblisseAbstractArt.github.io/Meiso-potage-flash-collection",
   "metapulse": "noyjoyluckclub.github.io/metapulse",
   "metascraper": "microlinkhq.github.io/metascraper",
   "meth": "meth-meth-method.github.io/meth",


### PR DESCRIPTION
- [x] I have read the [JS.ORG Terms of Service](https://js.org/terms.html) and agree to them.
- [x] I know that JS.ORG domains are not for commercial use and free of charge.
- [x] I know that JS.ORG is not a web host and I have to host my site on GitHub Pages.
- [x] I have created the `CNAME` file in my repository with my requested JS.ORG domain name.

### Target domain:
`mesopota.js.org`

### Target repository:
`IblisseAbstractArt.github.io/Meiso-potage-flash-collection`

### Content URL:
`https://IblisseAbstractArt.github.io/Meiso-potage-flash-collection`

### Content explanation:
This project is a digital preservation site for classic Flash animations from Meisou Potage. It utilizes JavaScript and WebAssembly (Ruffle) to allow users to interactively view and experience these legacy web artifacts directly in modern browsers.