### PR TITLE
aelnetwork.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -108,6 +108,7 @@ var cnames_active = {
   "adon988": "adon988.github.io",
   "adv": "advjs.github.io",
   "advancedrpc": "advancedrpc.github.io",
+  "aelnetwork": "ael-network.onrender.com", // noCF
   "aerogel": "noeldemartin.github.io/aerogel",
   "aesthetic": "esthetic-docs.netlify.app",
   "affiliate": "russellsteadman.github.io/affiliate",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [https://ael-network.onrender.com](https://ael-network.onrender.com)

> The site content is AEL, an open-source (Apache-2.0), dependency-free JavaScript blockchain devnet built for AI agents. The entire protocol — deterministic state machine, BFT consensus, Ed25519 signed intents, token program, wallet PWA, and one-file agent join client — is written in plain Node.js/browser JavaScript with zero runtime dependencies, and the site serves the live network portal, a JavaScript SDK, developer documentation, and an in-browser chain explorer. It is relevant to JavaScript developers specifically because it demonstrates how far the platform's built-ins (node:crypto, WebCrypto Ed25519, service workers) can be pushed to build an entire verifiable distributed system in JavaScript, and every artifact developers download from it (SDK, join client, follower node) is a runnable JS file. Note: the site runs on a free Render instance, so the first request after idle can take ~1 minute to wake.