### PR TITLE
trading-toolkit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3469,6 +3469,7 @@ var cnames_active = {
   "torpedo": "divysrivastava.github.io/torpedo.js",
   "trace": "andreasmadsen.github.io/trace",
   "trackymouse": "1j01.github.io/tracky-mouse",
+  "trading-toolkit": "trading-toolkit-web.pages.dev",
   "trakas": "trakas.github.io",
   "translate": "xuanzhi33.github.io/translate.js",
   "transposer": "francesco-dipi.github.io/transposer",


### PR DESCRIPTION
Request a JS.ORG subdomain for the public Vue-based trading toolkit web application hosted on Cloudflare Pages: https://trading-toolkit-web.pages.dev/