### PR TITLE
ascendantsmp.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -252,6 +252,7 @@ var cnames_active = {
   "artificial": "fabiosmuu.github.io/artificial",
   "artitalk": "artitalkjs.github.io/docs",
   "asdivyansh": "asdivyansh.github.io",
+  "ascendantsmp": "ali-2123.github.io/ascendentsmp.github.io",
   "aspectly": "jeanisahakyan.github.io/aspectly",
   "ass": "weizhenye.github.io/ASS",
   "ass-editor": "jeff-tian.github.io/ass",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: https://js.org/readme.html#no-content)
- [x] I have read and accepted the https://js.org/terms.html
- The site content can be seen at https://ali-2123.github.io/ascendentsmp.github.io/
- The site content is an interactive website and platform for our Minecraft community featuring web tools, server status trackers, and custom JavaScript web applications built specifically for community interactions.

- Domain: ascendantsmp.js.org
- Target: ali-2123.github.io/ascendentsmp.github.io
- Description: Website for Ascendant SMP project.