### PR TITLE
vocabrunner.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3695,6 +3695,7 @@ var cnames_active = {
   "vncz": "xvincentx.github.io/vncz",
   "vnpay": "cname.vercel-dns.com", // noCF
   "vocab": "battleofplassey.github.io/ministry-of-vocabulary",
+  "vocabrunner": "devsine.github.io/vocab-runner",
   "volantis": "volantis-x.github.io/community",
   "volantis-x": "volantis-x.github.io",
   "voloshins": "voloshins.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
**Requested subdomain:** `vocabrunner.js.org`
**Target:** `devsine.github.io/vocab-runner`

### What is it?
Vocab Runner is an open-source **JavaScript (three.js) 3D endless-runner game** for learning English vocabulary — Subway-Surfers-style, space-station theme. Read the Thai prompt, run into the lane with the correct English word; miss and a laser fires. Includes a Milky-Way bonus stage, spaced-repetition (Leitner) progress in localStorage, and 6 word decks (~1,000 words).

- Repo: https://github.com/DEVsine/vocab-runner
- Live: https://devsine.github.io/vocab-runner/
- 100% static, no backend. Served over HTTPS. Built with three.js (ES modules + import map, no bundler).

### Checklist
- [x] JavaScript-related project (three.js game, all client-side JS)
- [x] Real, working content (fully playable)
- [x] Served over HTTPS
- [x] Subdomain `vocabrunner` is available

### Note on CNAME
To avoid breaking the currently-shared `devsine.github.io/vocab-runner/` link during review (adding a GitHub Pages CNAME file 301-redirects it to the not-yet-live js.org domain), I've kept the CNAME file out for now. **I will add the `CNAME` file (`vocabrunner.js.org`) to the repo the moment this is approved/merged** so routing works immediately. Happy to add it earlier if you prefer — just let me know.