### PR TITLE
eggsy.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1017,7 +1017,6 @@ var cnames_active = {
   "effect-graphql": "egriff38.github.io/effect-graphql",
   "effectful": "awto.github.io/effectfuljs",
   "effects": "effectsjs.github.io/effectsjs",
-  "eggsy": "eggsywashere.github.io",
   "ehsan": "ehsanfox.github.io",
   "eight": "cnzc.github.io/eight",
   "eiphop": "eiphop.netlify.app",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://eggsy.js.org

> The site content is being removed from the list of active CNAMEs and is relevant to JavaScript developers specifically because it is an existing JS.org subdomain.