### PR TITLE
etude.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1106,6 +1106,7 @@ var cnames_active = {
   "eta": "alias.zeit.co", // noCF
   "eth": "eth-js.github.io/eth-dev-tools",
   "ethavatar": "filips123.github.io/EthAvatar.JS",
+  "etude": "onurcelep.github.io/etude",
   "euc": "wnda.github.io/euc",
   "euclid": "anandthakker.github.io/euclid", // noCF? (don´t add this in a new PR)
   "eva": "eva-engine.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page
- [x] I have read and accepted the [Terms and Conditions](https://js.org/terms.html)
- The site content can be seen at https://onurcelep.github.io/etude/

> The site content is a free, open-source (MIT) suite of browser-based practice tools for musicians, built entirely in vanilla JavaScript with no build step (Web Audio API, a WASM AudioWorklet time-stretcher, IndexedDB persistence, installable PWA), and it is relevant to JavaScript developers specifically because the whole product is readable, dependency-free JavaScript source on GitHub demonstrating advanced client-side audio engineering, and it ships a companion JS browser extension for Chrome and Firefox.

Additional context:

- Source: https://github.com/onurcelep/etude (the Looper tool is live at `/looper/`)
- Subdomain matches the repository name (`etude`)
- GitHub Pages (workflow publishing). I will set the custom domain `etude.js.org` in the repository's Pages settings the moment this PR merges — setting it before DNS exists redirects the currently-live site (linked from browser-extension store listings) into the js.org wildcard, which would also hide the content from reviewers.
- Resubmission of #12081, which I closed while briefly considering a paid domain and whose head branch was lost with the deleted fork. Sorry for the noise; this is the settled request.