### PR TITLE
w2d.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3739,7 +3739,7 @@ var cnames_active = {
   "vulkava": "hosting.gitbook.io", // noCF
   "vxt": "noah227.github.io/vxt-docs",
   "vxv": "vxv.netlify.app",
-  "w2d": "bananahackers.github.io/w2d", // noCF
+  "w2d": "bananahackers.github.io/w2d",
   "w4ctech": "w4ctech.github.io",
   "w4j1e": "w4j1e.github.io",
   "wahtson": "wahtson.github.io",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://github.com/bananahackers/w2d

> This is to remove the noCF flag for `w2d.js.org`. Initial submission of this domain is #9425:
> 
> The site content is: w2d is a JavaScript-based utility webpage used to open menu hidden within the Settings app on Firefox OS, KaiOS and alike. It utilises mozActivity API on Firefox OS/KaiOS 2.5 and webActivity API on KaiOS 3+. User can visit the site on their phone and click on the buttons to open the corresponding menu. It is relevant to JavaScript developers specifically because: it helps developers and enthusiasts access the certain hidden pages in Settings, where they can turn on debugging access and start developing apps for FFOS/KaiOS.
>
> mozActivity and webActivity APIs are widely available, and have been used by FFOS/KaiOS app developers to share content between apps (Tom has more [technical details on these APIs](https://kaios.dev/2023/02/web-activities-on-kaios/)).
>
> FFOS/KaiOS apps are web apps; they're written in HTML5, CSS and JavaScript, so w2d.js.org is indirectly helping the JavaScript developers who make apps on the platform.
> 
> In the far future W2D might be designed as a full dev tool for developers to play with mozActivity and webActivity APIs and interact with apps on the phone. But the main purpose of the page (for now) is to open Developer menu within the Settings app.
>
> JS code is based on https://w2d.bananahackers.net/ (kudos to @Tombarr, Luxferre and @cyan-2048). On behalf of the https://github.com/bananahackers team, I want to make this because T9 typing w2d.bananahackers.net is really difficult.
> 
> (W2D: web-to-developer menu; the page was originally designed to simply open the Developer menu.)