### PR TITLE
markupshift.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2013,6 +2013,7 @@ var cnames_active = {
   "markmap": "gera2ld.github.io/markmap-lib",
   "markmapu": "markmap-universe.github.io",
   "markmsmith": "markmsmith.github.io",
+  "markupshift": "malopestorres.github.io/markupshift",
   "markvis": "geekplux.github.io/markvis",
   "markvis-editor": "geekplux.github.io/markvis-editor",
   "markxmind": "jinzcdev.github.io/markxmind",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://malopestorres.github.io/markupshift/ and its source is available at https://github.com/malopestorres/markupshift

> The site content is MarkupShift, an open source, browser-based HTML-to-JSX/TSX converter. It is relevant to JavaScript developers specifically because it converts HTML structure, attributes, and inline styles into React JavaScript or TypeScript component source, supports splitting markup into named components, and exports ready-to-use JSX/TSX files.
