### PR TITLE
kinastudyjne.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1751,6 +1751,7 @@ var cnames_active = {
   "kilvin": "rofrischmann.github.io/kilvin",
   "kim": "khareemnurulla.github.io/kim",
   "kimera": "ultirequiem.github.io/kimera",
+  "kinastudyjne": "sajgonara.github.io/kina-studyjne",
   "kindavishal": "kindavishal.netlify.app",
   "kiranremmarasu": "kiranremmarasu.github.io/kiranremmarasu",
   "kiss": "sisyphuszheng.github.io/kiss",


### PR DESCRIPTION
## Add kinastudyjne.js.org

- **Subdomain**: kinastudyjne.js.org
- **Target**: sajgonara.github.io/kina-studyjne
- **Site content**: Interactive map + sortable list of Polish arthouse cinemas (Sieć Kin Studyjnych) with ticket prices — open source, non-commercial, built with Leaflet (JavaScript).
- Live now at: https://sajgonara.github.io/kina-studyjne/
- CNAME file is already in place: https://github.com/sajgonara/kina-studyjne/blob/main/CNAME

🤖 Generated with [Claude Code](https://claude.com/claude-code)