### PR TITLE
code-forge-coding.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -473,7 +473,7 @@ var cnames_active = {
   "bytemd": "bytemd.netlify.app",
   "c": "cocobear.github.io",
   "c-3po": "ttag-org.github.io/c-3po",
-  "code-forge-coding": "code-forge-coding.netlify.app",
+  "code-forge": "code-forge-coding.netlify.app",
   "c-installer": "llenax.github.io/c-installer",
   "c1200": "c1200.github.io",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -473,7 +473,7 @@ var cnames_active = {
   "bytemd": "bytemd.netlify.app",
   "c": "cocobear.github.io",
   "c-3po": "ttag-org.github.io/c-3po",
-  "code-forge": "code-forge-coding.netlify.app",
+  "code-forge-coding": "code-forge-coding.netlify.app",
   "c-installer": "llenax.github.io/c-installer",
   "c1200": "c1200.github.io",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -473,7 +473,7 @@ var cnames_active = {
   "bytemd": "bytemd.netlify.app",
   "c": "cocobear.github.io",
   "c-3po": "ttag-org.github.io/c-3po",
-  "code-forge": "https://code-forge-coding.netlify.app",
+  "code-forge-coding": "code-forge-coding.netlify.app",
   "c-installer": "llenax.github.io/c-installer",
   "c1200": "c1200.github.io",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -473,6 +473,7 @@ var cnames_active = {
   "bytemd": "bytemd.netlify.app",
   "c": "cocobear.github.io",
   "c-3po": "ttag-org.github.io/c-3po",
+  "code-forge": "https://code-forge-coding.netlify.app",
   "c-installer": "llenax.github.io/c-installer",
   "c1200": "c1200.github.io",
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)

--- a/cnames_active.js
+++ b/cnames_active.js
@@ -602,6 +602,7 @@ var cnames_active = {
   "cndrew": "codemaster233.github.io",
   "cobalt-kit": "bernzrdo.github.io/cobalt-kit",
   "cocy": "krmax44.github.io/cocy",
+  "code-forge-coding": "code-forge-coding.netlify.app",
   "code-tour": "code-tour.netlify.app",
   "codeberry": "cname.vercel-dns.com", // noCF
   "codebooky": "hiteshsubnani0128.github.io/codebooky",


### PR DESCRIPTION

- [x] There is reasonable content on the page (see: [CodeForge](https://code-forge-coding.netlify.app))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at [Code Forge](https://code-forge-coding.netlify.app)

This is relevant to JavaScript developers specifically because CodeForge is built for writing, testing, and sharing JS code and front-end projects in-browser — similar in purpose to tools like CodePen or JSFiddle. It's aimed at developers who want to quickly prototype, demo, or teach JavaScript without local tooling setup, and the "Publish Site" and "Export" features let JS devs ship small projects or share live demos directly from a subdomain.
