### PR TITLE
kavo.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1735,6 +1735,7 @@ var cnames_active = {
   "kasfy": "kasfy.github.io/kasfy.js.org",
   "kasumi": "cname.vercel-dns.com", // noCF
   "katheesh": "katheesh.github.io/katheesh.js",
+  "kavo": "kavo-labs.github.io/kavo",
   "kawaii": "moemoesoft.github.io/kawaii", // noCF
   "kcak11": "kcak11.github.io/js-org-web",
   "kelvinho": "kelvin2go.github.io", // noCF? (don´t add this in a new PR)


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://kavo-labs.github.io/kavo/

> The site content is the design documentation (architecture notes, ADRs, glossary) for Kavo, an open-source TypeScript CRUD framework, and is relevant to JavaScript developers specifically because it documents the public API, configuration model, and query grammar of a TypeScript CRUD framework that JavaScript/TypeScript developers use directly.