### PR TITLE
cadenceanimator.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -478,6 +478,7 @@ var cnames_active = {
   "cable": "whatgoodisaroad.github.io/cablejs", // noCF? (don´t add this in a new PR)
   "cachi": "eddiejibson.github.io/cachi",
   "cacophony": "ctoth.github.io/cacophony",
+  "cadenceanimator": "alycoulibal2-sketch.github.io/Cadence-Animator",
   "caffeine": "ccrraaiigg.github.io/caffeine",
   "caicai": "qianxunclub.github.io/CaiCai",
   "caissa": "agentx-cgn.github.io/caissa",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://alycoulibal2-sketch.github.io/Cadence-Animator/

> The site content is the documentation and download page for Cadence Animator, an open-source Electron and three.js desktop application distributed through npm (`npm install -g github:alycoulibal2-sketch/Cadence-Animator`), which also registers the Node-based Model Context Protocol server it ships. The site documents installing that npm package, running it from source, and the 135 MCP tools its Node server exposes, alongside the animation features themselves. It is relevant to JavaScript developers specifically because it documents an npm-distributed JavaScript tool and its MCP server, which is a Node package that JavaScript developers integrate with AI agent tooling — the MCP setup, tool catalogue and the `npm` install and run instructions are part of the documented content, not just the implementation language.

I should be straightforward about one thing so you can judge it fairly: the application's end users are Roblox animators, so much of the documentation covers animation workflows rather than JavaScript development. What is genuinely JavaScript-ecosystem-facing is that it is an npm-installed Electron/three.js tool shipping an MCP server for Node, and the site documents that installation and integration. If that is not a strong enough connection for js.org, I completely understand — please close this rather than stretching the criteria.

Repository: https://github.com/alycoulibal2-sketch/Cadence-Animator (MIT licensed)
The `CNAME` file containing `cadenceanimator.js.org` is already committed to the `gh-pages` branch that serves the site.