### PR TITLE
cockpit.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -600,6 +600,7 @@ var cnames_active = {
   "cnc": "cncjs.github.io/cncjs.org",
   "cndrew": "codemaster233.github.io",
   "cobalt-kit": "bernzrdo.github.io/cobalt-kit",
+  "cockpit": "noluyorabi.github.io/cockpit-claude",
   "cocy": "krmax44.github.io/cocy",
   "code-tour": "code-tour.netlify.app",
   "codeberry": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://noluyorabi.github.io/cockpit-claude/

> The site content is the documentation and an interactive demo for cockpit-claude, a zero-dependency Node CLI published on npm that renders a four-line statusline under the Claude Code prompt, and it is relevant to JavaScript developers specifically because the page documents a terminal tool that Node developers install with npx and run while they work, covering every segment it prints through a hoverable reference, a configuration guide, a stated list of the tool's limitations, and a live simulation that runs the same projection arithmetic as the published package.

Additional links:

- npm: https://www.npmjs.com/package/cockpit-claude
- Repository: https://github.com/noluyorAbi/cockpit-claude

Happy to make any changes you would like.
