### PR TITLE
poe2craft.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2587,6 +2587,7 @@ var cnames_active = {
   "plumier": "plumier.github.io",
   "pnpm": "pnpm.github.io",
   "pod": "mileallen.github.io/pod",
+  "poe2craft": "yacinebedd.github.io/PoE-Craft",
   "poegems": "max-arias.github.io/poeGems", // noCF? (don´t add this in a new PR)
   "pogo": "aaronduino.github.io/pogo",
   "pogtopia": "alexander9673.github.io/Pogtopia",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://yacinebedd.github.io/PoE-Craft/

> The site content is an open-source, framework-free JavaScript web application (the page is its own live demo) that models Path of Exile 2 item crafting with a client-side probability and Monte Carlo simulation engine, and it is relevant to JavaScript developers specifically because it is a complete, dependency-free ES-module reference implementation — a worked example of a data-driven simulation UI, a Monte Carlo cost estimator, and interactive state visualisation running entirely in the browser with no build step, whose full source is published for other JS developers to read, fork, and reuse.

---

**Subdomain naming note:** my repository is [`PoE-Craft`](https://github.com/YacineBedd/PoE-Craft) and I'm requesting `poe2craft` (with the `2`) because the project targets **Path of Exile _2_** specifically — the `2` is what makes the name clear and unambiguous. Per the contributing guidance, exceptions to exact repo-name matching are allowed "for the sake of clarity," and this is that case.

Target: `yacinebedd.github.io/PoE-Craft` — added in alphabetical order between `pod` and `poegems`; `node --check` passes on `cnames_active.js`. Thanks for maintaining JS.ORG! 🙏
