### PR TITLE
varvara.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3652,7 +3652,7 @@ var cnames_active = {
   "vanya": "cname.vercel-dns.com", // noCF
   "vapory": "vaporyjs.github.io",
   "various": "variousjs.github.io/website",
-  "varvara": "marcmarine.github.io/varvara",
+  "varvara": "marcmarine.github.io/varvara-js", // noCF
   "vayne": "vaynejs.github.io",
   "vbuild": "egoist.github.io/vbuild",
   "vdcs": "hopae-official.github.io/Verifiable-Digital-Credentials",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://varvara.js.org

> This PR is a **configuration change for the existing `varvara` subdomain** (originally added in #9137), not a new request. I'm asking to remove the Cloudflare proxy by adding the `//noCF` flag to the entry and I also updated the target URL. The GitHub Pages site is actually at `marcmarine.github.io/varvara-js` (the repository was renamed from `varvara` to `varvara-js`), so the old target `marcmarine.github.io/varvara` no longer points to the real site.
