### PR TITLE
pgs-cacaban.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2534,6 +2534,7 @@ var cnames_active = {
   "personalkanban": "nishantpainter.github.io/personal-kanban",
   "perspective": "leopoldthecoder.github.io/Perspective",
   "peter": "peterccpang.github.io",
+  "pgs-cacaban": "cname.vercel-dns.com",
   "pguth": "pguth.github.io",
   "ph1p": "ph1p.github.io",
   "phaker": "phakerjs.github.io/phaker.js",


### PR DESCRIPTION
### Domain Request: pgs-cacaban.js.org

- **Domain Name**: pgs-cacaban.js.org
- **Target**: cname.vercel-dns.com
- **Application**: Public RT 04 Resident Information System
- **Repository**: https://github.com/ch4plin01/pgs