### PR TITLE
nexvault.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2243,7 +2243,7 @@ var cnames_active = {
   "myurl": "marvnet.github.io/myurl",
   "mzaini30": "mzaini30.github.io",
   "mzplayer": "prince3661.github.io/Mzplayer",
-  "n": "cyb.github.io/n",
+  "n": "nexvault": "anderc18.github.io/NexVault",
   "nabin": "nabin6246.github.io",
   "nacl-check": "magnusmarx.github.io/NaCL",
   "naja": "naja-js.github.io/naja",


### PR DESCRIPTION
**URL:** https://anderc18.github.io/NexVault

**Explanation:** NexVault is a personal hub to organize and access 
links to games, Minecraft mods, APKs, textures, university files, 
and work documents. It is a static site hosted on GitHub Pages.