### PR TITLE
openmat.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2434,6 +2434,7 @@ var cnames_active = {
   "openauth": "openauthjs.github.io/openauth",
   "opencc": "opencc-wasm.pages.dev",
   "openkey": "microlinkhq.github.io/openkey",
+  "openmat": "dhve.github.io/openmat",
   "opennext": "opennextjs.github.io/docs",
   "openrecord": "philwaldmann.github.io/openrecord",
   "opentrivia-guide": "turtlepaw.github.io/trivia-docs",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://getopenmat.netlify.app

> The site content is the landing page and quick reference for OpenMat, an open-source Mathematica-style computational notebook whose web app is built in TypeScript and React (MathLive input, KaTeX rendering, SVG plotting) with its symbolic kernel compiled to WebAssembly and running entirely in the browser, and is relevant to JavaScript developers specifically because it documents a JS-ecosystem project they can run, embed, and contribute to: the page explains the notebook's TypeScript architecture, the browser WASM build, and how to develop it with npm and Vite.

Note for reviewers: the link above is a mirror of the exact GitHub Pages content. The Pages target (dhve.github.io/openmat) already serves the deployment with the required CNAME file, so it currently 301s to openmat.js.org and will resolve there the moment this is merged.