### PR TITLE
chatjs.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -544,6 +544,7 @@ var cnames_active = {
   "chariot": "riyacchi.github.io/chariot.js",
   "chatexchange": "jacob-gray.github.io/ChatExchangeJS",
   "chatgpt": "chatgptjs.github.io/chatgpt.js",
+  "chatjs": "hayamahamed.github.io/chatjs",
   "checkers": "davidpomerenke.github.io/checkers",
   "cheerio": "cheeriojs.github.io/cheerio",
   "chenkun": "ck123-rgb.github.io/chenkun-js-org",


### PR DESCRIPTION
- [x] There is reasonable content on the page.
- [x] I have read and accepted the [Terms and Conditions]
- The site content can be seen at https://hayamahamed.github.io/chatjs

> The site content is the landing page for ChatJS, an open-source rule-based chatbot licensed under MIT, written in JavaScript. It is designed to remove API costs and give precise responses with minimal setup by handling predictable conversations without relying on AI models for every request. By providing deterministic conversational flows and runnable examples, ChatJS improves performance and lowers operational expenses for web projects.

and it is relevant to JavaScript developers specifically because its written in javascript and what developers type in text file will be processed by the script to give output.

Note for reviewers: since I added the CNAME the GitHub URL will redirect to js.org. You may look at the repo at https://github.com/hayamahamed/chatjs or the live demo at https://chatjs.pages.dev.