### PR TITLE
vibe-coding-news.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3675,6 +3675,7 @@ var cnames_active = {
   "veza": "kyranet.github.io/veza",
   "vfm": "meshesha.github.io/VisualFormMaker.github.io",
   "viav": "brandondyer64.github.io/viav",
+  "vibe-coding-news": "almubarmij.github.io/Vibe-Coding-News",
   "vicis": "r37r0m0d3l.github.io/vicis",
   "vico": "bohdantkachenko.github.io/vico", // noCF? (don´t add this in a new PR)
   "vidclip": "cname.vercel-dns.com", // noCF


### PR DESCRIPTION
Requested subdomain: **vibe-coding-news.js.org**
Target: `almubarmij.github.io/Vibe-Coding-News`

A daily Arabic-language (RTL) links digest covering the AI-assisted / "vibe coding" developer tooling ecosystem — Cursor, Claude Code, GitHub Copilot, Codex, OpenCode, Windsurf, and the JavaScript/TypeScript tooling built around them. Each issue is a curated, categorised set of links with Arabic summaries, sourced from Hacker News and news RSS, with a permanent dated archive.

The site brings this ecosystem's news to an underserved Arabic-speaking developer audience.

- [x] Custom domain `vibe-coding-news.js.org` is set on the GitHub Pages repo (CNAME file present in `gh-pages`)
- [x] Site has substantive, non-placeholder content (24 curated items in the current issue, plus a dated archive)
- [x] No automatic redirects away from the js.org domain
- [x] Content stays focused on its stated topic
- [x] I have read and accept the js.org Terms and Conditions

Current live URL: https://almubarmij.github.io/Vibe-Coding-News/
