### PR TITLE
inkpad.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -1574,6 +1574,7 @@ var cnames_active = {
   "injectify": "injectify.github.io/docs",
   "ink": "colossalchicken.github.io/ink.js",
   "inko": "inko.netlify.app",
+  "inkpad": "inkpad-js.github.io/inkpad",
   "inline-style-prefixer": "rofrischmann.github.io/inline-style-prefixer",
   "innova": "innova-fll.github.io",
   "inscriptum": "sumbad.github.io/inscriptum",


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://inkpad-js.github.io/inkpad/

> The site content is Inkpad, a notes application whose entire implementation is the single `index.html` file that the page serves, and is relevant to JavaScript developers specifically because the page *is* its own source: a dependency-free, build-step-free reference implementation of a `contenteditable` rich-text editor, a snapshot-based undo stack, a Markdown parser and serializer, and browser-side Google Drive and GitHub Gist sync, all in vanilla JavaScript that a developer can read end to end with view-source.

Repository: https://github.com/inkpad-js/inkpad

The requested subdomain matches the project repository name (`inkpad`), as required. A `CNAME` file containing `inkpad.js.org` is committed at the repository root, and the site publishes from the `main` branch as a GitHub Pages project site.
