### PR TITLE
thoserows.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3434,6 +3434,7 @@ var cnames_active = {
   "thepeachtimes": "thepeachtimes.github.io",
   "thi": "ngomjnhthj.github.io/thi",
   "thinkdigital": "tomowens08.github.io/thinkdigital",
+  "thoserows": "jeffersonmoss.github.io/thoserows",
   "threadly": "spideyzac.github.io/Threadly",
   "threads": "andywer.github.io/threads.js",
   "threebody": "cnzc.github.io/threebody",


### PR DESCRIPTION
Requesting **thoserows.js.org** for Those Rows — a free, in-browser 3D cornrow & braid pattern designer (Three.js PWA, no build step, no backend).

- Target: `jeffersonmoss.github.io/thoserows` (GitHub Pages)
- CNAME file is in place and the site is live at the target.