### PR TITLE
ng-signal-query.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -2312,6 +2312,7 @@ var cnames_active = {
   "ng-dux": "mister-what.github.io/ngDux",
   "ng-eagleeye": "webkrafters.github.io/ng-eagleeye",
   "ng-monaco-editor": "alauda.github.io/ng-monaco-editor",
+  "ng-signal-query": "ali7040.github.io/ng-signal-query-site",
   "ng-wig": "stevermeister.github.io/ngWig", // noCF? (don´t add this in a new PR)
   "ngbook": "ngbook.github.io",
   "ngirc": "ngirc.github.io/ng-irc", // noCF


### PR DESCRIPTION
- [x] There is reasonable content on the page (see: [No Content](https://github.com/js-org/js.org/wiki/No-Content))
- [x] I have read and accepted the [Terms and Conditions](http://js.org/terms.html)
- The site content can be seen at https://ali7040.github.io/ng-signal-query-site/

> The site content is the documentation and an interactive playground for ng-signal-query, an MIT-licensed open-source JavaScript/TypeScript library published on npm as [`@ali7040/ng-signal-query`](https://www.npmjs.com/package/@ali7040/ng-signal-query). It is a server-state library for Angular built on signals, providing queries, mutations and caching. It is relevant to JavaScript developers specifically because its central topic is asynchronous concurrency control: the site documents four strategies for resolving overlapping async calls — `merge`, `concat`, `switch` and `exhaust` — which mirror the RxJS flattening operators `mergeMap`, `concatMap`, `switchMap` and `exhaustMap`. The playground is a working simulator where a developer places calls on a timeline, adjusts request duration, and watches each strategy resolve them, so it also serves as a teaching tool for RxJS semantics beyond this one library. The remainder of the page covers installation, request cancellation via `AbortSignal`, retry with exponential backoff, quick-start code examples, and a feature comparison against TanStack Query. There are no ads, no placeholder text and no portfolio content.

Additional links:

- Site repository: https://github.com/Ali7040/ng-signal-query-site
- Library repository: https://github.com/Ali7040/ng-signal-query
- npm package: https://www.npmjs.com/package/@ali7040/ng-signal-query
- `CNAME` is already in place and served at https://ali7040.github.io/ng-signal-query-site/CNAME

The entry was added in alphabetical order, between `ng-monaco-editor` and `ng-wig`.
