### PR TITLE
soilpepper.js.org

### DIFF
--- a/cnames_active.js
+++ b/cnames_active.js
@@ -3175,6 +3175,7 @@ var cnames_active = {
   "soloalert": "arnav-kr.github.io/soloalert",
   "solome": "solome.github.io",
   "solu": "soiu.github.io/solu",
+  "soilpepper": "aljezurai.github.io",
   "somerandomcat": "hosting.gitbook.io", // noCF
   "sonicware": "easyontop.github.io/Sonicware.js",
   "soniq": "fullstack-build.github.io/soniq",


### PR DESCRIPTION
By submitting this pull request, I confirm that my site is an Open Source project and hosted on GitHub Pages.

**soilpepper.js.org** → `aljezurai.github.io`

SOILPEPPER is a free, browser-based permaculture design toolkit: 14 self-contained HTML tools (master plan grid, water management, guild diagrams, vegetable garden planner with sowing specs, species filter, etc.) with 256 species data, Tuscany/Netherlands region presets. No server, no account — all data stays in the visitor's browser (localStorage).

- Repo: https://github.com/aljezurai/soilpepper
- CNAME file with `soilpepper.js.org` already committed to the repo's main branch
- Live at: https://aljezurai.github.io/soilpepper/

Reasonable content: fully working design tools with species database and interactive planners.